### PR TITLE
Fix npc issue

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -4,6 +4,7 @@
 
 build_bridge:
 	cd external/zenoh_carla_bridge && cargo build --release
+	poetry config virtualenvs.in-project true # Make sure poetry install .venv under carla_agent
 	cd external/zenoh_carla_bridge/carla_agent && poetry install --no-root
 
 build_autoware:


### PR DESCRIPTION
Fix #8 
Do not bridge NPC vehicles with Zenoh. We add "autoware_" before the role_name of the vehicle to distinguish our vehicle from NPC vehicles.