### PR TITLE
Able to listen the connection from the Autoware outside.

### DIFF
--- a/script/run-bridge.sh
+++ b/script/run-bridge.sh
@@ -6,6 +6,8 @@ mkdir -p ${LOG_PATH}
 # Note bridge should run later because it needs to configure Carla sync setting.
 # Python script will overwrite the settings if bridge run first.
 parallel --verbose --lb ::: \
-        "sleep 5 && RUST_LOG=z=info ${AUTOWARE_CARLA_ROOT}/external/zenoh_carla_bridge/target/release/zenoh_carla_bridge 2>&1 | tee ${LOG_PATH}/bridge.log" \
+        "sleep 5 && RUST_LOG=z=info ${AUTOWARE_CARLA_ROOT}/external/zenoh_carla_bridge/target/release/zenoh_carla_bridge \
+                --zenoh-listen tcp/0.0.0.0:7447 2>&1 | tee ${LOG_PATH}/bridge.log" \
         "poetry -C ${PYTHON_AGENT_PATH} run python3 ${PYTHON_AGENT_PATH}/main.py \
-                --host ${CARLA_SIMULATOR_IP} --rolename ${VEHICLE_NAME} 2>&1 | tee ${LOG_PATH}/vehicle.log"
+                --host ${CARLA_SIMULATOR_IP} --rolename ${VEHICLE_NAME} \
+                2>&1 | tee ${LOG_PATH}/vehicle.log"


### PR DESCRIPTION
Fix the issue #26 
`run-bridge-two-vehicles.sh` listen to `tcp/0.0.0.0:7447` but `run-bridge.sh` doesn't have this settings.
