### PR TITLE
.gitignore changes: More precies matching and ignore editor files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,16 +1,23 @@
 # ROS data
-install
-build
-log
+/install/
+/build/
+/log/
 
 # Compile tools
-rust
-poetry
-pyenv
+/rust/
+/poetry/
+/pyenv/
 
 # Bridge
-bridge_log
-autoware_log
+/bridge_log/
+/autoware_log/
 
 # Ignore autoware source code
-autoware
+/autoware/
+
+# Ignore editor files
+*~
+.*~
+\#*#
+*.swp
+*.swo


### PR DESCRIPTION
It changes the line

```diff
- autoware_log
+ /autoware_log/
```

so it matches the autoware\_log folder (by ending /) exactly at the root directory (by starting /).

More entries are added to .gitignore to ignore files generated by editors.