### PR TITLE
Configure ros2dds to operate in peer mode

### DIFF
--- a/config/zenoh-bridge-ros2dds-conf.json5
+++ b/config/zenoh-bridge-ros2dds-conf.json5
@@ -1,4 +1,5 @@
 {
+  mode: "peer",
   plugins: {
     ros2dds: {
       allow: {


### PR DESCRIPTION
This PR aligns the ros2dds behavior with that of the `humble` branch by setting its operation mode to `peer`. The change responds to the default mode shift introduced in zenoh-plugin-ros2dds 0.11.0, as detailed in issue #108.
