### PR TITLE
Fix use CARLA address in zenoh_carla_bridge start script

### DIFF
--- a/script/run-bridge-two-vehicles-v2x.sh
+++ b/script/run-bridge-two-vehicles-v2x.sh
@@ -9,7 +9,7 @@ mkdir -p ${LOG_PATH}
 # Python script will overwrite the settings if bridge run first.
 parallel --verbose --lb ::: \
         "sleep 5 && RUST_LOG=z=info ${AUTOWARE_CARLA_ROOT}/external/zenoh_carla_bridge/target/release/zenoh_carla_bridge \
-                --mode ros2 --zenoh-listen tcp/0.0.0.0:7447 2>&1 | tee ${LOG_PATH}/bridge.log" \
+                --mode ros2 --zenoh-listen tcp/0.0.0.0:7447 --carla-address ${CARLA_SIMULATOR_IP} 2>&1 | tee ${LOG_PATH}/bridge.log" \
         "poetry -C ${PYTHON_AGENT_PATH} run python3 ${PYTHON_AGENT_PATH}/main.py \
                 --host ${CARLA_SIMULATOR_IP} --rolename 'v1' \
                 --position 87.687683,145.671295,0.300000,0.000000,90.000053,0.000000 \

--- a/script/run-bridge-two-vehicles.sh
+++ b/script/run-bridge-two-vehicles.sh
@@ -10,7 +10,7 @@ mkdir -p ${LOG_PATH}
 # Python script will overwrite the settings if bridge run first.
 parallel --verbose --lb ::: \
         "sleep 5 && RUST_LOG=z=info ${AUTOWARE_CARLA_ROOT}/external/zenoh_carla_bridge/target/release/zenoh_carla_bridge \
-                --mode ros2 --zenoh-listen tcp/0.0.0.0:7447 --slowdown 2 2>&1 | tee ${LOG_PATH}/bridge.log" \
+                --mode ros2 --zenoh-listen tcp/0.0.0.0:7447 --carla-address ${CARLA_SIMULATOR_IP} --slowdown 2 2>&1 | tee ${LOG_PATH}/bridge.log" \
         "poetry -C ${PYTHON_AGENT_PATH} run python3 ${PYTHON_AGENT_PATH}/main.py \
                 --host ${CARLA_SIMULATOR_IP} --rolename 'v1' \
                 --position 87.687683,145.671295,0.300000,0.000000,90.000053,0.000000 \

--- a/script/run-bridge-v2x.sh
+++ b/script/run-bridge-v2x.sh
@@ -9,7 +9,7 @@ mkdir -p ${LOG_PATH}
 # Python script will overwrite the settings if bridge run first.
 parallel --verbose --lb ::: \
         "sleep 5 && RUST_LOG=z=info ${AUTOWARE_CARLA_ROOT}/external/zenoh_carla_bridge/target/release/zenoh_carla_bridge \
-                --mode ros2 --zenoh-listen tcp/0.0.0.0:7447 2>&1 | tee ${LOG_PATH}/bridge.log" \
+                --mode ros2 --zenoh-listen tcp/0.0.0.0:7447 --carla-address ${CARLA_SIMULATOR_IP} 2>&1 | tee ${LOG_PATH}/bridge.log" \
         "sleep 1 && poetry -C ${PYTHON_AGENT_PATH} run python3 ${PYTHON_AGENT_PATH}/main.py \
                 --host ${CARLA_SIMULATOR_IP} --rolename ${VEHICLE_NAME} \
                 --position 87.784805,20.787275,0.881736,16.499052,90.000053,0.000000 \

--- a/script/run-bridge.sh
+++ b/script/run-bridge.sh
@@ -10,7 +10,7 @@ mkdir -p ${LOG_PATH}
 # Python script will overwrite the settings if bridge run first.
 parallel --verbose --lb ::: \
         "sleep 5 && RUST_LOG=z=info ${AUTOWARE_CARLA_ROOT}/external/zenoh_carla_bridge/target/release/zenoh_carla_bridge \
-                --mode ros2 --zenoh-listen tcp/0.0.0.0:7447 2>&1 | tee ${LOG_PATH}/bridge.log" \
+                --mode ros2 --zenoh-listen tcp/0.0.0.0:7447 --carla-address ${CARLA_SIMULATOR_IP} 2>&1 | tee ${LOG_PATH}/bridge.log" \
         "poetry -C ${PYTHON_AGENT_PATH} run python3 ${PYTHON_AGENT_PATH}/main.py \
                 --host ${CARLA_SIMULATOR_IP} --rolename ${VEHICLE_NAME} \
                 2>&1 | tee ${LOG_PATH}/vehicle.log"


### PR DESCRIPTION
This PR ensures the CARLA simulator address defined in `env.sh` is utilized in the bridge start script as detailed in issue #110.