### PR TITLE
Set Autoware version to 2024/09/03

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -25,6 +25,8 @@ prepare_autoware:
 	sudo apt update
 	rosdep update --rosdistro=${ROS_DISTRO}
 	rosdep install -y --from-paths src --ignore-src --rosdistro ${ROS_DISTRO}
+	# Prebuild models
+	./script/build_models.sh
 
 build_bridge:
 	cd external/zenoh_carla_bridge && cargo build --release

--- a/container/Dockerfile_autoware
+++ b/container/Dockerfile_autoware
@@ -1,4 +1,4 @@
-FROM ghcr.io/autowarefoundation/autoware:20240905-devel-cuda-amd64
+FROM ghcr.io/autowarefoundation/autoware:20240903-devel-cuda-amd64
 
 # Download necessary packages
 RUN apt-get update

--- a/container/Dockerfile_autoware_src
+++ b/container/Dockerfile_autoware_src
@@ -1,4 +1,4 @@
-FROM ghcr.io/autowarefoundation/autoware:20240905-devel-cuda-amd64
+FROM ghcr.io/autowarefoundation/autoware:20240903-devel-cuda-amd64
 
 # Download necessary packages
 RUN apt-get update

--- a/container/Dockerfile_carla_bridge
+++ b/container/Dockerfile_carla_bridge
@@ -1,4 +1,4 @@
-FROM ghcr.io/autowarefoundation/autoware:20240905-devel-cuda-amd64
+FROM ghcr.io/autowarefoundation/autoware:20240903-devel-cuda-amd64
 
 # Download necessary packages
 RUN apt-get update

--- a/container/run-autoware-docker-src.sh
+++ b/container/run-autoware-docker-src.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-DOCKER_IMAGE=zenoh-autoware-src-2024-9-3
+DOCKER_IMAGE=zenoh-autoware-src-20240903
 DOCKER_FILE=container/Dockerfile_autoware_src
 AUTOWARE_VERSION=2024.09
 

--- a/container/run-autoware-docker-src.sh
+++ b/container/run-autoware-docker-src.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-DOCKER_IMAGE=zenoh-autoware-src-2024-9
+DOCKER_IMAGE=zenoh-autoware-src-2024-9-3
 DOCKER_FILE=container/Dockerfile_autoware_src
 AUTOWARE_VERSION=2024.09
 

--- a/container/run-autoware-docker.sh
+++ b/container/run-autoware-docker.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-DOCKER_IMAGE=zenoh-autoware-2024-9-3
+DOCKER_IMAGE=zenoh-autoware-20240903
 DOCKER_FILE=container/Dockerfile_autoware
 
 if [ ! "$(docker images -q ${DOCKER_IMAGE})" ]; then

--- a/container/run-autoware-docker.sh
+++ b/container/run-autoware-docker.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-DOCKER_IMAGE=zenoh-autoware-2024-9
+DOCKER_IMAGE=zenoh-autoware-2024-9-3
 DOCKER_FILE=container/Dockerfile_autoware
 
 if [ ! "$(docker images -q ${DOCKER_IMAGE})" ]; then

--- a/container/run-bridge-docker.sh
+++ b/container/run-bridge-docker.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-DOCKER_IMAGE=zenoh-carla-bridge-2024-9
+DOCKER_IMAGE=zenoh-carla-bridge-2024-9-3
 DOCKER_FILE=container/Dockerfile_carla_bridge
 
 if [ ! "$(docker images -q ${DOCKER_IMAGE})" ]; then

--- a/container/run-bridge-docker.sh
+++ b/container/run-bridge-docker.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-DOCKER_IMAGE=zenoh-carla-bridge-2024-9-3
+DOCKER_IMAGE=zenoh-carla-bridge-20240903
 DOCKER_FILE=container/Dockerfile_carla_bridge
 
 if [ ! "$(docker images -q ${DOCKER_IMAGE})" ]; then

--- a/docs/faq.rst
+++ b/docs/faq.rst
@@ -51,3 +51,15 @@ FAQ
         pip install sphinx
         sphinx-build -a docs /tmp/mydocs
         xdg-open /tmp/mydocs/index.html
+
+6. How to change the lidar detection model for object detection?
+
+    - In the env.sh file located in your project directory, you can adjust the lidar detection model by modifying the LIDAR_DETECTION_MODEL environment variable. The available options are "centerpoint", "apollo", "transfusion", or "disable" to disable lidar detection. 
+    
+    - If you choose "centerpoint", you can also select a specific model version by modifying the CENTERPOINT_MODEL_NAME variable. The available options are "centerpoint" and "centerpoint_tiny".
+    
+    - After making changes, save the file and reload the environment by running:
+
+    .. code-block:: bash
+
+        source env.sh

--- a/docs/faq.rst
+++ b/docs/faq.rst
@@ -60,6 +60,6 @@ FAQ
     
     - After making changes, save the file and reload the environment by running:
 
-    .. code-block:: bash
+        .. code-block:: bash
 
-        source env.sh
+            source env.sh

--- a/docs/faq.rst
+++ b/docs/faq.rst
@@ -54,9 +54,9 @@ FAQ
 
 6. How to change the lidar detection model for object detection?
 
-    - In the env.sh file located in your project directory, you can adjust the lidar detection model by modifying the LIDAR_DETECTION_MODEL environment variable. The available options are "centerpoint", "apollo", "transfusion", or "disable" to disable lidar detection. 
+    - In the ``env.sh`` file located in your project directory, you can adjust the lidar detection model by modifying the ``LIDAR_DETECTION_MODEL`` environment variable. The available options are "centerpoint", "apollo", "transfusion", or "disable" to disable lidar detection. 
     
-    - If you choose "centerpoint", you can also select a specific model version by modifying the CENTERPOINT_MODEL_NAME variable. The available options are "centerpoint" and "centerpoint_tiny".
+    - If you choose "centerpoint", you can also select a specific model version by modifying the ``CENTERPOINT_MODEL_NAME`` variable. The available options are "centerpoint" and "centerpoint_tiny".
     
     - After making changes, save the file and reload the environment by running:
 

--- a/env.sh
+++ b/env.sh
@@ -61,6 +61,9 @@ export VEHICLE_NAME="v1"
 # Set the ccache directory to /tmp to avoid permission issue
 export CCACHE_DIR=/tmp/ccache
 
+# Enable/Disable lidar detection model functionality ("centerpoint", "apollo", "transfusion", or "disable")
+export LIDAR_DETECTION_MODEL="centerpoint"
+
 # Rust path (Only needed while using docker)
 if [ -f /.dockerenv ]; then
     RUST_PATH=${AUTOWARE_CARLA_ROOT}/rust

--- a/env.sh
+++ b/env.sh
@@ -64,6 +64,10 @@ export CCACHE_DIR=/tmp/ccache
 # Enable/Disable lidar detection model functionality ("centerpoint", "apollo", "transfusion", or "disable")
 export LIDAR_DETECTION_MODEL="centerpoint"
 
+# Set centerpoint model ("centerpoint", "centerpoint_tiny")
+# It is used when LIDAR_DETECTION_MODEL is set as "centerpoint"
+export CENTERPOINT_MODEL_NAME="centerpoint_tiny"
+
 # Rust path (Only needed while using docker)
 if [ -f /.dockerenv ]; then
     RUST_PATH=${AUTOWARE_CARLA_ROOT}/rust

--- a/script/build_models.sh
+++ b/script/build_models.sh
@@ -1,0 +1,16 @@
+#!/usr/bin/env bash
+set -e
+
+# lidar centerpoint (tiny)
+ros2 launch autoware_lidar_centerpoint lidar_centerpoint.launch.xml \
+	model_name:=centerpoint_tiny \
+	model_path:=$AUTOWARE_CARLA_ROOT/autoware_data/lidar_centerpoint \
+	model_param_path:=$(ros2 pkg prefix autoware_launch --share)/config/perception/object_recognition/detection/lidar_model/centerpoint_tiny.param.yaml \
+	build_only:=true
+
+# lidar transfusion
+ros2 launch autoware_lidar_transfusion lidar_transfusion.launch.xml \
+        model_name:=transfusion \
+        model_path:=$AUTOWARE_CARLA_ROOT/autoware_data/lidar_transfusion \
+        model_param_path:=$(ros2 pkg prefix autoware_launch --share)/config/perception/object_recognition/detection/lidar_model/transfusion.param.yaml \
+        build_only:=true

--- a/script/build_models.sh
+++ b/script/build_models.sh
@@ -8,6 +8,15 @@ ros2 launch autoware_lidar_centerpoint lidar_centerpoint.launch.xml \
 	model_param_path:=$(ros2 pkg prefix autoware_launch --share)/config/perception/object_recognition/detection/lidar_model/centerpoint_tiny.param.yaml \
 	build_only:=true
 
+
+# lidar centerpoint
+ros2 launch autoware_lidar_centerpoint lidar_centerpoint.launch.xml \
+        model_name:=centerpoint \
+        model_path:=$AUTOWARE_CARLA_ROOT/autoware_data/lidar_centerpoint \
+        model_param_path:=$(ros2 pkg prefix autoware_launch --share)/config/perception/object_recognition/detection/lidar_model/centerpoint.param.yaml \
+        build_only:=true
+
+
 # lidar transfusion
 ros2 launch autoware_lidar_transfusion lidar_transfusion.launch.xml \
         model_name:=transfusion \

--- a/src/autoware_carla_launch/rviz/autoware.rviz
+++ b/src/autoware_carla_launch/rviz/autoware.rviz
@@ -5,10 +5,12 @@ Panels:
     Property Tree Widget:
       Expanded:
         - /Sensing1/LiDAR1/ConcatenatePointCloud1/Autocompute Value Bounds1
-        - /Image1
+        - /Perception1/ObjectRecognition1/Prediction1
+        - /Perception1/ObjectRecognition1/Prediction1/PredictedObjects1
+        - /Perception1/TrafficLight1
         - /Image1/Topic1
       Splitter Ratio: 0.557669460773468
-    Tree Height: 443
+    Tree Height: 263
   - Class: rviz_common/Selection
     Name: Selection
   - Class: rviz_common/Tool Properties
@@ -20,8 +22,6 @@ Panels:
       - /Current View1
     Name: Views
     Splitter Ratio: 0.5
-  - Class: tier4_localization_rviz_plugin/InitialPoseButtonPanel
-    Name: InitialPoseButtonPanel
   - Class: AutowareDateTimePanel
     Name: AutowareDateTimePanel
   - Class: rviz_plugins::AutowareStatePanel
@@ -65,56 +65,6 @@ Visualization Manager:
           Value: false
         - Class: rviz_common/Group
           Displays:
-            - Class: rviz_plugins/SteeringAngle
-              Enabled: true
-              Left: 64
-              Length: 128
-              Name: SteeringAngle
-              Scale: 17
-              Text Color: 25; 255; 240
-              Top: 64
-              Topic:
-                Depth: 5
-                Durability Policy: Volatile
-                History Policy: Keep Last
-                Reliability Policy: Reliable
-                Value: /vehicle/status/steering_status
-              Value: true
-              Value Scale: 0.14999249577522278
-              Value height offset: 0
-            - Class: rviz_plugins/ConsoleMeter
-              Enabled: true
-              Left: 256
-              Length: 128
-              Name: ConsoleMeter
-              Text Color: 25; 255; 240
-              Top: 64
-              Topic:
-                Depth: 5
-                Durability Policy: Volatile
-                History Policy: Keep Last
-                Reliability Policy: Reliable
-                Value: /vehicle/status/velocity_status
-              Value: true
-              Value Scale: 0.14999249577522278
-              Value height offset: 0
-            - Alpha: 0.9990000128746033
-              Class: rviz_plugins/VelocityHistory
-              Color Border Vel Max: 3
-              Constant Color:
-                Color: 255; 255; 255
-                Value: true
-              Enabled: true
-              Name: VelocityHistory
-              Scale: 0.30000001192092896
-              Timeout: 10
-              Topic:
-                Depth: 5
-                Durability Policy: Volatile
-                History Policy: Keep Last
-                Reliability Policy: Reliable
-                Value: /vehicle/status/velocity_status
-              Value: true
             - Alpha: 0.30000001192092896
               Class: rviz_default_plugins/RobotModel
               Collision Enabled: false
@@ -256,32 +206,24 @@ Visualization Manager:
               Value: true
               Wave Color: 255; 255; 255
               Wave Velocity: 40
-            - Class: rviz_plugins/MaxVelocity
-              Enabled: true
-              Left: 298
-              Length: 48
-              Name: MaxVelocity
-              Text Color: 255; 255; 255
-              Top: 140
-              Topic: /planning/scenario_planning/current_max_velocity
-              Value: true
-              Value Scale: 0.25
-            - Class: rviz_plugins/TurnSignal
-              Enabled: true
-              Height: 128
-              Left: 98
-              Name: TurnSignal
-              Top: 175
-              Topic:
-                Depth: 5
-                Durability Policy: Volatile
-                History Policy: Keep Last
-                Reliability Policy: Reliable
-                Value: /vehicle/status/turn_indicators_status
-              Value: true
-              Width: 256
           Enabled: true
           Name: Vehicle
+        - Class: rviz_plugins/MrmSummaryOverlayDisplay
+          Enabled: false
+          Font Size: 10
+          Left: 512
+          Max Letter Num: 100
+          Name: MRM Summary
+          Text Color: 25; 255; 240
+          Top: 64
+          Topic:
+            Depth: 5
+            Durability Policy: Volatile
+            History Policy: Keep Last
+            Reliability Policy: Reliable
+            Value: /system/emergency/hazard_status
+          Value: false
+          Value height offset: 0
       Enabled: true
       Name: System
     - Class: rviz_common/Group
@@ -597,12 +539,7 @@ Visualization Manager:
               Enabled: true
               Name: MonteCarloInitialPose
               Namespaces:
-                initial_pose_index_color_marker: true
-                initial_pose_iteration_color_marker: true
-                initial_pose_transform_probability_color_marker: true
-                result_pose_index_color_marker: true
-                result_pose_iteration_color_marker: true
-                result_pose_transform_probability_color_marker: true
+                {}
               Topic:
                 Depth: 5
                 Durability Policy: Volatile
@@ -688,15 +625,21 @@ Visualization Manager:
                   CYCLIST:
                     Alpha: 0.9990000128746033
                     Color: 119; 11; 32
-                  Class: autoware_auto_perception_rviz_plugin/DetectedObjects
+                  Class: autoware_perception_rviz_plugin/DetectedObjects
+                  Confidence Interval: 95%
                   Display Acceleration: true
+                  Display Existence Probability: false
                   Display Label: true
-                  Display PoseWithCovariance: true
+                  Display Pose Covariance: true
                   Display Predicted Path Confidence: true
                   Display Predicted Paths: true
                   Display Twist: true
+                  Display Twist Covariance: false
                   Display UUID: true
                   Display Velocity: true
+                  Display Yaw Covariance: false
+                  Display Yaw Rate: false
+                  Display Yaw Rate Covariance: false
                   Enabled: true
                   Line Width: 0.029999999329447746
                   MOTORCYCLE:
@@ -705,6 +648,7 @@ Visualization Manager:
                   Name: DetectedObjects
                   Namespaces:
                     {}
+                  Object Fill Type: skeleton
                   PEDESTRIAN:
                     Alpha: 0.9990000128746033
                     Color: 255; 192; 203
@@ -739,15 +683,22 @@ Visualization Manager:
                   CYCLIST:
                     Alpha: 0.9990000128746033
                     Color: 119; 11; 32
-                  Class: autoware_auto_perception_rviz_plugin/TrackedObjects
+                  Class: autoware_perception_rviz_plugin/TrackedObjects
+                  Confidence Interval: 95%
                   Display Acceleration: true
+                  Display Existence Probability: false
                   Display Label: true
-                  Display PoseWithCovariance: true
+                  Display Pose Covariance: true
                   Display Predicted Path Confidence: true
                   Display Predicted Paths: true
                   Display Twist: true
+                  Display Twist Covariance: false
                   Display UUID: true
                   Display Velocity: true
+                  Display Yaw Covariance: false
+                  Display Yaw Rate: false
+                  Display Yaw Rate Covariance: false
+                  Dynamic Status: All
                   Enabled: true
                   Line Width: 0.029999999329447746
                   MOTORCYCLE:
@@ -756,6 +707,7 @@ Visualization Manager:
                   Name: TrackedObjects
                   Namespaces:
                     {}
+                  Object Fill Type: skeleton
                   PEDESTRIAN:
                     Alpha: 0.9990000128746033
                     Color: 255; 192; 203
@@ -790,15 +742,21 @@ Visualization Manager:
                   CYCLIST:
                     Alpha: 0.9990000128746033
                     Color: 119; 11; 32
-                  Class: autoware_auto_perception_rviz_plugin/PredictedObjects
+                  Class: autoware_perception_rviz_plugin/PredictedObjects
+                  Confidence Interval: 95%
                   Display Acceleration: true
+                  Display Existence Probability: false
                   Display Label: true
-                  Display PoseWithCovariance: false
+                  Display Pose Covariance: true
                   Display Predicted Path Confidence: true
                   Display Predicted Paths: true
                   Display Twist: true
+                  Display Twist Covariance: false
                   Display UUID: true
                   Display Velocity: true
+                  Display Yaw Covariance: false
+                  Display Yaw Rate: false
+                  Display Yaw Rate Covariance: false
                   Enabled: true
                   Line Width: 0.029999999329447746
                   MOTORCYCLE:
@@ -806,14 +764,8 @@ Visualization Manager:
                     Color: 119; 11; 32
                   Name: PredictedObjects
                   Namespaces:
-                    acceleration: true
-                    label: true
-                    path: true
-                    path confidence: true
-                    shape: true
-                    twist: true
-                    uuid: true
-                    velocity: true
+                    {}
+                  Object Fill Type: skeleton
                   PEDESTRIAN:
                     Alpha: 0.9990000128746033
                     Color: 255; 192; 203
@@ -865,7 +817,7 @@ Visualization Manager:
                 Durability Policy: Volatile
                 History Policy: Keep Last
                 Reliability Policy: Best Effort
-                Value: /perception/traffic_light_recognition/debug/rois
+                Value: /perception/traffic_light_recognition/traffic_light/debug/rois
               Value: false
             - Class: rviz_default_plugins/MarkerArray
               Enabled: true
@@ -916,11 +868,7 @@ Visualization Manager:
               Enabled: true
               Name: RouteArea
               Namespaces:
-                goal_lanelets: true
-                lane_start_bound: true
-                left_lane_bound: true
-                right_lane_bound: true
-                route_lanelets: true
+                {}
               Topic:
                 Depth: 5
                 Durability Policy: Transient Local
@@ -948,6 +896,18 @@ Visualization Manager:
                 Reliability Policy: Reliable
                 Value: /planning/mission_planning/echo_back_goal_pose
               Value: true
+            - Background Alpha: 0.30000001192092896
+              Background Color: 0; 0; 0
+              Class: autoware_mission_details_overlay_rviz_plugin/MissionDetailsDisplay
+              Enabled: true
+              Height: 100
+              Name: MissionDetailsDisplay
+              Remaining Distance and Time Topic: /planning/mission_remaining_distance_time
+              Right: 10
+              Text Color: 194; 194; 194
+              Top: 10
+              Value: true
+              Width: 170
           Enabled: true
           Name: MissionPlanning
         - Class: rviz_common/Group
@@ -968,10 +928,10 @@ Visualization Manager:
                 Alpha: 1
                 Color: 230; 230; 50
                 Offset from BaseLink: 0
-                Rear Overhang: 1.0299999713897705
+                Rear Overhang: 1.100000023841858
                 Value: false
-                Vehicle Length: 4.769999980926514
-                Vehicle Width: 1.8300000429153442
+                Vehicle Length: 4.889999866485596
+                Vehicle Width: 1.8960000276565552
               View Path:
                 Alpha: 0.9990000128746033
                 Color: 0; 0; 0
@@ -984,6 +944,9 @@ Visualization Manager:
                 Color: 0; 60; 255
                 Offset: 0
                 Radius: 0.10000000149011612
+                Value: false
+              View Text Slope:
+                Scale: 0.30000001192092896
                 Value: false
               View Text Velocity:
                 Scale: 0.30000001192092896
@@ -1019,10 +982,10 @@ Visualization Manager:
                         Alpha: 1
                         Color: 230; 230; 50
                         Offset from BaseLink: 0
-                        Rear Overhang: 1.0299999713897705
+                        Rear Overhang: 1.100000023841858
                         Value: false
-                        Vehicle Length: 4.769999980926514
-                        Vehicle Width: 1.8300000429153442
+                        Vehicle Length: 4.889999866485596
+                        Vehicle Width: 1.8960000276565552
                       View Path:
                         Alpha: 0.4000000059604645
                         Color: 0; 0; 0
@@ -1036,6 +999,9 @@ Visualization Manager:
                         Offset: 0
                         Radius: 0.10000000149011612
                         Value: false
+                      View Text Slope:
+                        Scale: 0.30000001192092896
+                        Value: false
                       View Text Velocity:
                         Scale: 0.30000001192092896
                         Value: false
@@ -1047,8 +1013,358 @@ Visualization Manager:
                         Value: true
                     - Class: rviz_plugins/Path
                       Color Border Vel Max: 3
+                      Enabled: false
+                      Name: PathReference_AvoidanceByLC
+                      Topic:
+                        Depth: 5
+                        Durability Policy: Volatile
+                        Filter size: 10
+                        History Policy: Keep Last
+                        Reliability Policy: Reliable
+                        Value: /planning/path_reference/avoidance_by_lane_change
+                      Value: false
+                      View Drivable Area:
+                        Alpha: 0.9990000128746033
+                        Color: 0; 148; 205
+                        Value: true
+                        Width: 0.30000001192092896
+                      View Footprint:
+                        Alpha: 1
+                        Color: 230; 230; 50
+                        Offset from BaseLink: 0
+                        Rear Overhang: 1.0299999713897705
+                        Value: false
+                        Vehicle Length: 4.769999980926514
+                        Vehicle Width: 1.8300000429153442
+                      View Path:
+                        Alpha: 0.30000001192092896
+                        Color: 210; 110; 10
+                        Constant Color: true
+                        Constant Width: false
+                        Value: true
+                        Width: 2
+                      View Point:
+                        Alpha: 1
+                        Color: 0; 60; 255
+                        Offset: 0
+                        Radius: 0.10000000149011612
+                        Value: false
+                      View Text Slope:
+                        Scale: 0.30000001192092896
+                        Value: false
+                      View Text Velocity:
+                        Scale: 0.30000001192092896
+                        Value: false
+                      View Velocity:
+                        Alpha: 0.30000001192092896
+                        Color: 0; 0; 0
+                        Constant Color: false
+                        Scale: 0.30000001192092896
+                        Value: false
+                    - Class: rviz_plugins/Path
+                      Color Border Vel Max: 3
+                      Enabled: false
+                      Name: PathReference_Avoidance
+                      Topic:
+                        Depth: 5
+                        Durability Policy: Volatile
+                        Filter size: 10
+                        History Policy: Keep Last
+                        Reliability Policy: Reliable
+                        Value: /planning/path_reference/static_obstacle_avoidance
+                      Value: false
+                      View Drivable Area:
+                        Alpha: 0.9990000128746033
+                        Color: 0; 148; 205
+                        Value: true
+                        Width: 0.30000001192092896
+                      View Footprint:
+                        Alpha: 1
+                        Color: 230; 230; 50
+                        Offset from BaseLink: 0
+                        Rear Overhang: 1.0299999713897705
+                        Value: false
+                        Vehicle Length: 4.769999980926514
+                        Vehicle Width: 1.8300000429153442
+                      View Path:
+                        Alpha: 0.30000001192092896
+                        Color: 210; 110; 210
+                        Constant Color: true
+                        Constant Width: false
+                        Value: true
+                        Width: 2
+                      View Point:
+                        Alpha: 1
+                        Color: 0; 60; 255
+                        Offset: 0
+                        Radius: 0.10000000149011612
+                        Value: false
+                      View Text Slope:
+                        Scale: 0.30000001192092896
+                        Value: false
+                      View Text Velocity:
+                        Scale: 0.30000001192092896
+                        Value: false
+                      View Velocity:
+                        Alpha: 0.30000001192092896
+                        Color: 0; 0; 0
+                        Constant Color: false
+                        Scale: 0.30000001192092896
+                        Value: false
+                    - Class: rviz_plugins/Path
+                      Color Border Vel Max: 3
+                      Enabled: false
+                      Name: PathReference_LaneChangeRight
+                      Topic:
+                        Depth: 5
+                        Durability Policy: Volatile
+                        Filter size: 10
+                        History Policy: Keep Last
+                        Reliability Policy: Reliable
+                        Value: /planning/path_reference/lane_change_right
+                      Value: false
+                      View Drivable Area:
+                        Alpha: 0.9990000128746033
+                        Color: 0; 148; 205
+                        Value: true
+                        Width: 0.30000001192092896
+                      View Footprint:
+                        Alpha: 1
+                        Color: 230; 230; 50
+                        Offset from BaseLink: 0
+                        Rear Overhang: 1.0299999713897705
+                        Value: false
+                        Vehicle Length: 4.769999980926514
+                        Vehicle Width: 1.8300000429153442
+                      View Path:
+                        Alpha: 0.30000001192092896
+                        Color: 210; 210; 110
+                        Constant Color: true
+                        Constant Width: false
+                        Value: true
+                        Width: 2
+                      View Point:
+                        Alpha: 1
+                        Color: 0; 60; 255
+                        Offset: 0
+                        Radius: 0.10000000149011612
+                        Value: false
+                      View Text Slope:
+                        Scale: 0.30000001192092896
+                        Value: false
+                      View Text Velocity:
+                        Scale: 0.30000001192092896
+                        Value: false
+                      View Velocity:
+                        Alpha: 0.30000001192092896
+                        Color: 0; 0; 0
+                        Constant Color: false
+                        Scale: 0.30000001192092896
+                        Value: false
+                    - Class: rviz_plugins/Path
+                      Color Border Vel Max: 3
+                      Enabled: false
+                      Name: PathReference_LaneChangeLeft
+                      Topic:
+                        Depth: 5
+                        Durability Policy: Volatile
+                        Filter size: 10
+                        History Policy: Keep Last
+                        Reliability Policy: Reliable
+                        Value: /planning/path_reference/lane_change_left
+                      Value: false
+                      View Drivable Area:
+                        Alpha: 0.9990000128746033
+                        Color: 0; 148; 205
+                        Value: true
+                        Width: 0.30000001192092896
+                      View Footprint:
+                        Alpha: 1
+                        Color: 230; 230; 50
+                        Offset from BaseLink: 0
+                        Rear Overhang: 1.0299999713897705
+                        Value: false
+                        Vehicle Length: 4.769999980926514
+                        Vehicle Width: 1.8300000429153442
+                      View Path:
+                        Alpha: 0.30000001192092896
+                        Color: 210; 210; 110
+                        Constant Color: true
+                        Constant Width: false
+                        Value: true
+                        Width: 2
+                      View Point:
+                        Alpha: 1
+                        Color: 0; 60; 255
+                        Offset: 0
+                        Radius: 0.10000000149011612
+                        Value: false
+                      View Text Slope:
+                        Scale: 0.30000001192092896
+                        Value: false
+                      View Text Velocity:
+                        Scale: 0.30000001192092896
+                        Value: false
+                      View Velocity:
+                        Alpha: 0.30000001192092896
+                        Color: 0; 0; 0
+                        Constant Color: false
+                        Scale: 0.30000001192092896
+                        Value: false
+                    - Class: rviz_plugins/Path
+                      Color Border Vel Max: 3
+                      Enabled: false
+                      Name: PathReference_GoalPlanner
+                      Topic:
+                        Depth: 5
+                        Durability Policy: Volatile
+                        Filter size: 10
+                        History Policy: Keep Last
+                        Reliability Policy: Reliable
+                        Value: /planning/path_reference/goal_planner
+                      Value: false
+                      View Drivable Area:
+                        Alpha: 0.9990000128746033
+                        Color: 0; 148; 205
+                        Value: true
+                        Width: 0.30000001192092896
+                      View Footprint:
+                        Alpha: 1
+                        Color: 230; 230; 50
+                        Offset from BaseLink: 0
+                        Rear Overhang: 1.0299999713897705
+                        Value: false
+                        Vehicle Length: 4.769999980926514
+                        Vehicle Width: 1.8300000429153442
+                      View Path:
+                        Alpha: 0.30000001192092896
+                        Color: 110; 110; 210
+                        Constant Color: true
+                        Constant Width: false
+                        Value: true
+                        Width: 2
+                      View Point:
+                        Alpha: 1
+                        Color: 0; 60; 255
+                        Offset: 0
+                        Radius: 0.10000000149011612
+                        Value: false
+                      View Text Slope:
+                        Scale: 0.30000001192092896
+                        Value: false
+                      View Text Velocity:
+                        Scale: 0.30000001192092896
+                        Value: false
+                      View Velocity:
+                        Alpha: 0.30000001192092896
+                        Color: 0; 0; 0
+                        Constant Color: false
+                        Scale: 0.30000001192092896
+                        Value: false
+                    - Class: rviz_plugins/Path
+                      Color Border Vel Max: 3
+                      Enabled: false
+                      Name: PathReference_StartPlanner
+                      Topic:
+                        Depth: 5
+                        Durability Policy: Volatile
+                        Filter size: 10
+                        History Policy: Keep Last
+                        Reliability Policy: Reliable
+                        Value: /planning/path_reference/start_planner
+                      Value: false
+                      View Drivable Area:
+                        Alpha: 0.9990000128746033
+                        Color: 0; 148; 205
+                        Value: true
+                        Width: 0.30000001192092896
+                      View Footprint:
+                        Alpha: 1
+                        Color: 230; 230; 50
+                        Offset from BaseLink: 0
+                        Rear Overhang: 1.0299999713897705
+                        Value: false
+                        Vehicle Length: 4.769999980926514
+                        Vehicle Width: 1.8300000429153442
+                      View Path:
+                        Alpha: 0.30000001192092896
+                        Color: 210; 110; 110
+                        Constant Color: true
+                        Constant Width: false
+                        Value: true
+                        Width: 2
+                      View Point:
+                        Alpha: 1
+                        Color: 0; 60; 255
+                        Offset: 0
+                        Radius: 0.10000000149011612
+                        Value: false
+                      View Text Slope:
+                        Scale: 0.30000001192092896
+                        Value: false
+                      View Text Velocity:
+                        Scale: 0.30000001192092896
+                        Value: false
+                      View Velocity:
+                        Alpha: 0.30000001192092896
+                        Color: 0; 0; 0
+                        Constant Color: false
+                        Scale: 0.30000001192092896
+                        Value: false
+                    - Class: rviz_plugins/Path
+                      Color Border Vel Max: 3
                       Enabled: true
-                      Name: PathChangeCandidate_LaneChange
+                      Name: PathChangeCandidate_AvoidanceByLC
+                      Topic:
+                        Depth: 5
+                        Durability Policy: Volatile
+                        Filter size: 10
+                        History Policy: Keep Last
+                        Reliability Policy: Reliable
+                        Value: /planning/path_candidate/avoidance_by_lane_change
+                      Value: true
+                      View Drivable Area:
+                        Alpha: 0.9990000128746033
+                        Color: 0; 148; 205
+                        Value: true
+                        Width: 0.30000001192092896
+                      View Footprint:
+                        Alpha: 1
+                        Color: 230; 230; 50
+                        Offset from BaseLink: 0
+                        Rear Overhang: 1.100000023841858
+                        Value: false
+                        Vehicle Length: 4.889999866485596
+                        Vehicle Width: 1.8960000276565552
+                      View Path:
+                        Alpha: 0.30000001192092896
+                        Color: 115; 210; 22
+                        Constant Color: false
+                        Constant Width: false
+                        Value: true
+                        Width: 2
+                      View Point:
+                        Alpha: 1
+                        Color: 0; 60; 255
+                        Offset: 0
+                        Radius: 0.10000000149011612
+                        Value: false
+                      View Text Slope:
+                        Scale: 0.30000001192092896
+                        Value: false
+                      View Text Velocity:
+                        Scale: 0.30000001192092896
+                        Value: false
+                      View Velocity:
+                        Alpha: 0.30000001192092896
+                        Color: 0; 0; 0
+                        Constant Color: false
+                        Scale: 0.30000001192092896
+                        Value: false
+                    - Class: rviz_plugins/Path
+                      Color Border Vel Max: 3
+                      Enabled: true
+                      Name: (old)PathChangeCandidate_LaneChange
                       Topic:
                         Depth: 5
                         Durability Policy: Volatile
@@ -1083,6 +1399,209 @@ Visualization Manager:
                         Offset: 0
                         Radius: 0.10000000149011612
                         Value: false
+                      View Text Slope:
+                        Scale: 0.30000001192092896
+                        Value: false
+                      View Text Velocity:
+                        Scale: 0.30000001192092896
+                        Value: false
+                      View Velocity:
+                        Alpha: 0.30000001192092896
+                        Color: 0; 0; 0
+                        Constant Color: false
+                        Scale: 0.30000001192092896
+                        Value: false
+                    - Class: rviz_plugins/Path
+                      Color Border Vel Max: 3
+                      Enabled: true
+                      Name: PathChangeCandidate_LaneChangeRight
+                      Topic:
+                        Depth: 5
+                        Durability Policy: Volatile
+                        Filter size: 10
+                        History Policy: Keep Last
+                        Reliability Policy: Reliable
+                        Value: /planning/path_candidate/lane_change_right
+                      Value: true
+                      View Drivable Area:
+                        Alpha: 0.9990000128746033
+                        Color: 0; 148; 205
+                        Value: true
+                        Width: 0.30000001192092896
+                      View Footprint:
+                        Alpha: 1
+                        Color: 230; 230; 50
+                        Offset from BaseLink: 0
+                        Rear Overhang: 1.100000023841858
+                        Value: false
+                        Vehicle Length: 4.889999866485596
+                        Vehicle Width: 1.8960000276565552
+                      View Path:
+                        Alpha: 0.30000001192092896
+                        Color: 115; 210; 22
+                        Constant Color: false
+                        Constant Width: false
+                        Value: true
+                        Width: 2
+                      View Point:
+                        Alpha: 1
+                        Color: 0; 60; 255
+                        Offset: 0
+                        Radius: 0.10000000149011612
+                        Value: false
+                      View Text Slope:
+                        Scale: 0.30000001192092896
+                        Value: false
+                      View Text Velocity:
+                        Scale: 0.30000001192092896
+                        Value: false
+                      View Velocity:
+                        Alpha: 0.30000001192092896
+                        Color: 0; 0; 0
+                        Constant Color: false
+                        Scale: 0.30000001192092896
+                        Value: false
+                    - Class: rviz_plugins/Path
+                      Color Border Vel Max: 3
+                      Enabled: true
+                      Name: PathChangeCandidate_LaneChangeLeft
+                      Topic:
+                        Depth: 5
+                        Durability Policy: Volatile
+                        Filter size: 10
+                        History Policy: Keep Last
+                        Reliability Policy: Reliable
+                        Value: /planning/path_candidate/lane_change_left
+                      Value: true
+                      View Drivable Area:
+                        Alpha: 0.9990000128746033
+                        Color: 0; 148; 205
+                        Value: true
+                        Width: 0.30000001192092896
+                      View Footprint:
+                        Alpha: 1
+                        Color: 230; 230; 50
+                        Offset from BaseLink: 0
+                        Rear Overhang: 1.100000023841858
+                        Value: false
+                        Vehicle Length: 4.889999866485596
+                        Vehicle Width: 1.8960000276565552
+                      View Path:
+                        Alpha: 0.30000001192092896
+                        Color: 115; 210; 22
+                        Constant Color: false
+                        Constant Width: false
+                        Value: true
+                        Width: 2
+                      View Point:
+                        Alpha: 1
+                        Color: 0; 60; 255
+                        Offset: 0
+                        Radius: 0.10000000149011612
+                        Value: false
+                      View Text Slope:
+                        Scale: 0.30000001192092896
+                        Value: false
+                      View Text Velocity:
+                        Scale: 0.30000001192092896
+                        Value: false
+                      View Velocity:
+                        Alpha: 0.30000001192092896
+                        Color: 0; 0; 0
+                        Constant Color: false
+                        Scale: 0.30000001192092896
+                        Value: false
+                    - Class: rviz_plugins/Path
+                      Color Border Vel Max: 3
+                      Enabled: true
+                      Name: PathChangeCandidate_ExternalRequestLaneChangeRight
+                      Topic:
+                        Depth: 5
+                        Durability Policy: Volatile
+                        Filter size: 10
+                        History Policy: Keep Last
+                        Reliability Policy: Reliable
+                        Value: /planning/path_candidate/external_request_lane_change_right
+                      Value: true
+                      View Drivable Area:
+                        Alpha: 0.9990000128746033
+                        Color: 0; 148; 205
+                        Value: true
+                        Width: 0.30000001192092896
+                      View Footprint:
+                        Alpha: 1
+                        Color: 230; 230; 50
+                        Offset from BaseLink: 0
+                        Rear Overhang: 1.0299999713897705
+                        Value: false
+                        Vehicle Length: 4.769999980926514
+                        Vehicle Width: 1.8300000429153442
+                      View Path:
+                        Alpha: 0.30000001192092896
+                        Color: 115; 210; 22
+                        Constant Color: false
+                        Constant Width: false
+                        Value: true
+                        Width: 2
+                      View Point:
+                        Alpha: 1
+                        Color: 0; 60; 255
+                        Offset: 0
+                        Radius: 0.10000000149011612
+                        Value: false
+                      View Text Slope:
+                        Scale: 0.30000001192092896
+                        Value: false
+                      View Text Velocity:
+                        Scale: 0.30000001192092896
+                        Value: false
+                      View Velocity:
+                        Alpha: 0.30000001192092896
+                        Color: 0; 0; 0
+                        Constant Color: false
+                        Scale: 0.30000001192092896
+                        Value: false
+                    - Class: rviz_plugins/Path
+                      Color Border Vel Max: 3
+                      Enabled: true
+                      Name: PathChangeCandidate_ExternalRequestLaneChangeLeft
+                      Topic:
+                        Depth: 5
+                        Durability Policy: Volatile
+                        Filter size: 10
+                        History Policy: Keep Last
+                        Reliability Policy: Reliable
+                        Value: /planning/path_candidate/external_request_lane_change_left
+                      Value: true
+                      View Drivable Area:
+                        Alpha: 0.9990000128746033
+                        Color: 0; 148; 205
+                        Value: true
+                        Width: 0.30000001192092896
+                      View Footprint:
+                        Alpha: 1
+                        Color: 230; 230; 50
+                        Offset from BaseLink: 0
+                        Rear Overhang: 1.0299999713897705
+                        Value: false
+                        Vehicle Length: 4.769999980926514
+                        Vehicle Width: 1.8300000429153442
+                      View Path:
+                        Alpha: 0.30000001192092896
+                        Color: 115; 210; 22
+                        Constant Color: false
+                        Constant Width: false
+                        Value: true
+                        Width: 2
+                      View Point:
+                        Alpha: 1
+                        Color: 0; 60; 255
+                        Offset: 0
+                        Radius: 0.10000000149011612
+                        Value: false
+                      View Text Slope:
+                        Scale: 0.30000001192092896
+                        Value: false
                       View Text Velocity:
                         Scale: 0.30000001192092896
                         Value: false
@@ -1102,7 +1621,7 @@ Visualization Manager:
                         Filter size: 10
                         History Policy: Keep Last
                         Reliability Policy: Reliable
-                        Value: /planning/path_candidate/avoidance
+                        Value: /planning/path_candidate/static_obstacle_avoidance
                       Value: true
                       View Drivable Area:
                         Alpha: 0.9990000128746033
@@ -1113,10 +1632,10 @@ Visualization Manager:
                         Alpha: 1
                         Color: 230; 230; 50
                         Offset from BaseLink: 0
-                        Rear Overhang: 1.0299999713897705
+                        Rear Overhang: 1.100000023841858
                         Value: false
-                        Vehicle Length: 4.769999980926514
-                        Vehicle Width: 1.8300000429153442
+                        Vehicle Length: 4.889999866485596
+                        Vehicle Width: 1.8960000276565552
                       View Path:
                         Alpha: 0.30000001192092896
                         Color: 115; 210; 22
@@ -1129,6 +1648,9 @@ Visualization Manager:
                         Color: 0; 60; 255
                         Offset: 0
                         Radius: 0.10000000149011612
+                        Value: false
+                      View Text Slope:
+                        Scale: 0.30000001192092896
                         Value: false
                       View Text Velocity:
                         Scale: 0.30000001192092896
@@ -1142,14 +1664,14 @@ Visualization Manager:
                     - Class: rviz_plugins/Path
                       Color Border Vel Max: 3
                       Enabled: true
-                      Name: PathChangeCandidate_PullOut
+                      Name: PathChangeCandidate_StartPlanner
                       Topic:
                         Depth: 5
                         Durability Policy: Volatile
                         Filter size: 10
                         History Policy: Keep Last
                         Reliability Policy: Reliable
-                        Value: /planning/path_candidate/pull_out
+                        Value: /planning/path_candidate/start_planner
                       Value: true
                       View Drivable Area:
                         Alpha: 0.9990000128746033
@@ -1160,10 +1682,10 @@ Visualization Manager:
                         Alpha: 1
                         Color: 230; 230; 50
                         Offset from BaseLink: 0
-                        Rear Overhang: 1.0299999713897705
+                        Rear Overhang: 1.100000023841858
                         Value: false
-                        Vehicle Length: 4.769999980926514
-                        Vehicle Width: 1.8300000429153442
+                        Vehicle Length: 4.889999866485596
+                        Vehicle Width: 1.8960000276565552
                       View Path:
                         Alpha: 0.30000001192092896
                         Color: 115; 210; 22
@@ -1176,6 +1698,9 @@ Visualization Manager:
                         Color: 0; 60; 255
                         Offset: 0
                         Radius: 0.10000000149011612
+                        Value: false
+                      View Text Slope:
+                        Scale: 0.30000001192092896
                         Value: false
                       View Text Velocity:
                         Scale: 0.30000001192092896
@@ -1189,14 +1714,14 @@ Visualization Manager:
                     - Class: rviz_plugins/Path
                       Color Border Vel Max: 3
                       Enabled: true
-                      Name: PathChangeCandidate_PullOver
+                      Name: PathChangeCandidate_GoalPlanner
                       Topic:
                         Depth: 5
                         Durability Policy: Volatile
                         Filter size: 10
                         History Policy: Keep Last
                         Reliability Policy: Reliable
-                        Value: /planning/path_candidate/pull_over
+                        Value: /planning/path_candidate/goal_planner
                       Value: true
                       View Drivable Area:
                         Alpha: 0.9990000128746033
@@ -1207,10 +1732,10 @@ Visualization Manager:
                         Alpha: 1
                         Color: 230; 230; 50
                         Offset from BaseLink: 0
-                        Rear Overhang: 1.0299999713897705
+                        Rear Overhang: 1.100000023841858
                         Value: false
-                        Vehicle Length: 4.769999980926514
-                        Vehicle Width: 1.8300000429153442
+                        Vehicle Length: 4.889999866485596
+                        Vehicle Width: 1.8960000276565552
                       View Path:
                         Alpha: 0.30000001192092896
                         Color: 115; 210; 22
@@ -1223,6 +1748,9 @@ Visualization Manager:
                         Color: 0; 60; 255
                         Offset: 0
                         Radius: 0.10000000149011612
+                        Value: false
+                      View Text Slope:
+                        Scale: 0.30000001192092896
                         Value: false
                       View Text Velocity:
                         Scale: 0.30000001192092896
@@ -1234,20 +1762,115 @@ Visualization Manager:
                         Scale: 0.30000001192092896
                         Value: false
                     - Class: rviz_default_plugins/MarkerArray
-                      Enabled: true
+                      Enabled: false
                       Name: Bound
                       Namespaces:
-                        left_bound: true
-                        right_bound: true
+                        {}
                       Topic:
                         Depth: 5
                         Durability Policy: Volatile
                         History Policy: Keep Last
                         Reliability Policy: Reliable
                         Value: /planning/scenario_planning/lane_driving/behavior_planning/behavior_path_planner/debug/bound
-                      Value: true
+                      Value: false
                     - Class: rviz_common/Group
                       Displays:
+                        - Class: rviz_default_plugins/MarkerArray
+                          Enabled: true
+                          Name: VirtualWall (StaticObstacleAvoidance)
+                          Namespaces:
+                            {}
+                          Topic:
+                            Depth: 5
+                            Durability Policy: Volatile
+                            History Policy: Keep Last
+                            Reliability Policy: Reliable
+                            Value: /planning/scenario_planning/lane_driving/behavior_planning/behavior_path_planner/virtual_wall/static_obstacle_avoidance
+                          Value: true
+                        - Class: rviz_default_plugins/MarkerArray
+                          Enabled: true
+                          Name: VirtualWall (AvoidanceByLC)
+                          Namespaces:
+                            {}
+                          Topic:
+                            Depth: 5
+                            Durability Policy: Volatile
+                            History Policy: Keep Last
+                            Reliability Policy: Reliable
+                            Value: /planning/scenario_planning/lane_driving/behavior_planning/behavior_path_planner/virtual_wall/avoidance_by_lane_change
+                          Value: true
+                        - Class: rviz_default_plugins/MarkerArray
+                          Enabled: true
+                          Name: VirtualWall (LaneChangeRight)
+                          Namespaces:
+                            {}
+                          Topic:
+                            Depth: 5
+                            Durability Policy: Volatile
+                            History Policy: Keep Last
+                            Reliability Policy: Reliable
+                            Value: /planning/scenario_planning/lane_driving/behavior_planning/behavior_path_planner/virtual_wall/lane_change_right
+                          Value: true
+                        - Class: rviz_default_plugins/MarkerArray
+                          Enabled: true
+                          Name: VirtualWall (LaneChangeLeft)
+                          Namespaces:
+                            {}
+                          Topic:
+                            Depth: 5
+                            Durability Policy: Volatile
+                            History Policy: Keep Last
+                            Reliability Policy: Reliable
+                            Value: /planning/scenario_planning/lane_driving/behavior_planning/behavior_path_planner/virtual_wall/lane_change_left
+                          Value: true
+                        - Class: rviz_default_plugins/MarkerArray
+                          Enabled: true
+                          Name: VirtualWall (ExtLaneChangeRight)
+                          Namespaces:
+                            {}
+                          Topic:
+                            Depth: 5
+                            Durability Policy: Volatile
+                            History Policy: Keep Last
+                            Reliability Policy: Reliable
+                            Value: /planning/scenario_planning/lane_driving/behavior_planning/behavior_path_planner/virtual_wall/external_request_lane_change_right
+                          Value: true
+                        - Class: rviz_default_plugins/MarkerArray
+                          Enabled: true
+                          Name: VirtualWall (ExtLaneChangeLeft)
+                          Namespaces:
+                            {}
+                          Topic:
+                            Depth: 5
+                            Durability Policy: Volatile
+                            History Policy: Keep Last
+                            Reliability Policy: Reliable
+                            Value: /planning/scenario_planning/lane_driving/behavior_planning/behavior_path_planner/virtual_wall/external_request_lane_change_left
+                          Value: true
+                        - Class: rviz_default_plugins/MarkerArray
+                          Enabled: true
+                          Name: VirtualWall (GoalPlanner)
+                          Namespaces:
+                            {}
+                          Topic:
+                            Depth: 5
+                            Durability Policy: Volatile
+                            History Policy: Keep Last
+                            Reliability Policy: Reliable
+                            Value: /planning/scenario_planning/lane_driving/behavior_planning/behavior_path_planner/virtual_wall/goal_planner
+                          Value: true
+                        - Class: rviz_default_plugins/MarkerArray
+                          Enabled: true
+                          Name: VirtualWall (StartPlanner)
+                          Namespaces:
+                            {}
+                          Topic:
+                            Depth: 5
+                            Durability Policy: Volatile
+                            History Policy: Keep Last
+                            Reliability Policy: Reliable
+                            Value: /planning/scenario_planning/lane_driving/behavior_planning/behavior_path_planner/virtual_wall/start_planner
+                          Value: true
                         - Class: rviz_default_plugins/MarkerArray
                           Enabled: true
                           Name: VirtualWall (BlindSpot)
@@ -1271,6 +1894,18 @@ Visualization Manager:
                             History Policy: Keep Last
                             Reliability Policy: Reliable
                             Value: /planning/scenario_planning/lane_driving/behavior_planning/behavior_velocity_planner/virtual_wall/crosswalk
+                          Value: true
+                        - Class: rviz_default_plugins/MarkerArray
+                          Enabled: true
+                          Name: VirtualWall (Walkway)
+                          Namespaces:
+                            {}
+                          Topic:
+                            Depth: 5
+                            Durability Policy: Volatile
+                            History Policy: Keep Last
+                            Reliability Policy: Reliable
+                            Value: /planning/scenario_planning/lane_driving/behavior_planning/behavior_velocity_planner/virtual_wall/walkway
                           Value: true
                         - Class: rviz_default_plugins/MarkerArray
                           Enabled: true
@@ -1391,6 +2026,18 @@ Visualization Manager:
                             History Policy: Keep Last
                             Reliability Policy: Reliable
                             Value: /planning/scenario_planning/lane_driving/behavior_planning/behavior_velocity_planner/virtual_wall/speed_bump
+                          Value: true
+                        - Class: rviz_default_plugins/MarkerArray
+                          Enabled: true
+                          Name: VirtualWall (NoDrivableLane)
+                          Namespaces:
+                            {}
+                          Topic:
+                            Depth: 5
+                            Durability Policy: Volatile
+                            History Policy: Keep Last
+                            Reliability Policy: Reliable
+                            Value: /planning/scenario_planning/lane_driving/behavior_planning/behavior_velocity_planner/virtual_wall/no_drivable_lane
                           Value: true
                       Enabled: true
                       Name: VirtualWall
@@ -1530,7 +2177,7 @@ Visualization Manager:
                           Value: false
                         - Class: rviz_default_plugins/MarkerArray
                           Enabled: false
-                          Name: Avoidance
+                          Name: StaticObstacleAvoidance
                           Namespaces:
                             {}
                           Topic:
@@ -1538,11 +2185,11 @@ Visualization Manager:
                             Durability Policy: Volatile
                             History Policy: Keep Last
                             Reliability Policy: Reliable
-                            Value: /planning/scenario_planning/lane_driving/behavior_planning/behavior_path_planner/debug/avoidance
+                            Value: /planning/scenario_planning/lane_driving/behavior_planning/behavior_path_planner/debug/static_obstacle_avoidance
                           Value: false
                         - Class: rviz_default_plugins/MarkerArray
                           Enabled: false
-                          Name: LaneChange
+                          Name: LeftLaneChange
                           Namespaces:
                             {}
                           Topic:
@@ -1550,7 +2197,19 @@ Visualization Manager:
                             Durability Policy: Volatile
                             History Policy: Keep Last
                             Reliability Policy: Reliable
-                            Value: /planning/scenario_planning/lane_driving/behavior_planning/behavior_path_planner/debug/lanechange
+                            Value: /planning/scenario_planning/lane_driving/behavior_planning/behavior_path_planner/debug/lane_change_left
+                          Value: false
+                        - Class: rviz_default_plugins/MarkerArray
+                          Enabled: false
+                          Name: RightLaneChange
+                          Namespaces:
+                            {}
+                          Topic:
+                            Depth: 5
+                            Durability Policy: Volatile
+                            History Policy: Keep Last
+                            Reliability Policy: Reliable
+                            Value: /planning/scenario_planning/lane_driving/behavior_planning/behavior_path_planner/debug/lane_change_right
                           Value: false
                         - Class: rviz_default_plugins/MarkerArray
                           Enabled: false
@@ -1562,11 +2221,11 @@ Visualization Manager:
                             Durability Policy: Volatile
                             History Policy: Keep Last
                             Reliability Policy: Reliable
-                            Value: /planning/scenario_planning/lane_driving/behavior_planning/behavior_path_planner/debug/lanefollowing
+                            Value: /planning/scenario_planning/lane_driving/behavior_planning/behavior_path_planner/debug/lane_following
                           Value: false
                         - Class: rviz_default_plugins/MarkerArray
                           Enabled: false
-                          Name: PullOver
+                          Name: GoalPlanner
                           Namespaces:
                             {}
                           Topic:
@@ -1574,11 +2233,11 @@ Visualization Manager:
                             Durability Policy: Volatile
                             History Policy: Keep Last
                             Reliability Policy: Reliable
-                            Value: /planning/scenario_planning/lane_driving/behavior_planning/behavior_path_planner/debug/pullover
+                            Value: /planning/scenario_planning/lane_driving/behavior_planning/behavior_path_planner/debug/goal_planner
                           Value: false
                         - Class: rviz_default_plugins/MarkerArray
                           Enabled: false
-                          Name: PullOut
+                          Name: StartPlanner
                           Namespaces:
                             {}
                           Topic:
@@ -1586,7 +2245,7 @@ Visualization Manager:
                             Durability Policy: Volatile
                             History Policy: Keep Last
                             Reliability Policy: Reliable
-                            Value: /planning/scenario_planning/lane_driving/behavior_planning/behavior_path_planner/debug/pullout
+                            Value: /planning/scenario_planning/lane_driving/behavior_planning/behavior_path_planner/debug/start_planner
                           Value: false
                         - Class: rviz_default_plugins/MarkerArray
                           Enabled: false
@@ -1598,7 +2257,7 @@ Visualization Manager:
                             Durability Policy: Volatile
                             History Policy: Keep Last
                             Reliability Policy: Reliable
-                            Value: /planning/scenario_planning/lane_driving/behavior_planning/behavior_path_planner/debug/sideshift
+                            Value: /planning/scenario_planning/lane_driving/behavior_planning/behavior_path_planner/debug/side_shift
                           Value: false
                         - Class: rviz_default_plugins/MarkerArray
                           Enabled: false
@@ -1612,8 +2271,144 @@ Visualization Manager:
                             Reliability Policy: Reliable
                             Value: /planning/scenario_planning/lane_driving/behavior_planning/behavior_velocity_planner/debug/speed_bump
                           Value: false
+                        - Class: rviz_default_plugins/MarkerArray
+                          Enabled: false
+                          Name: DynamicObstacleAvoidance
+                          Namespaces:
+                            {}
+                          Topic:
+                            Depth: 5
+                            Durability Policy: Volatile
+                            History Policy: Keep Last
+                            Reliability Policy: Reliable
+                            Value: /planning/scenario_planning/lane_driving/behavior_planning/behavior_path_planner/debug/dynamic_obstacle_avoidance
+                          Value: false
+                        - Class: rviz_default_plugins/MarkerArray
+                          Enabled: false
+                          Name: NoDrivableLane
+                          Namespaces:
+                            {}
+                          Topic:
+                            Depth: 5
+                            Durability Policy: Volatile
+                            History Policy: Keep Last
+                            Reliability Policy: Reliable
+                            Value: /planning/scenario_planning/lane_driving/behavior_planning/behavior_velocity_planner/debug/no_drivable_lane
+                          Value: false
                       Enabled: false
                       Name: DebugMarker
+                    - Class: rviz_common/Group
+                      Displays:
+                        - Class: rviz_default_plugins/MarkerArray
+                          Enabled: false
+                          Name: Info (StaticObstacleAvoidance)
+                          Namespaces:
+                            {}
+                          Topic:
+                            Depth: 5
+                            Durability Policy: Volatile
+                            History Policy: Keep Last
+                            Reliability Policy: Reliable
+                            Value: /planning/scenario_planning/lane_driving/behavior_planning/behavior_path_planner/info/static_obstacle_avoidance
+                          Value: false
+                        - Class: rviz_default_plugins/MarkerArray
+                          Enabled: false
+                          Name: Info (AvoidanceByLC)
+                          Namespaces:
+                            {}
+                          Topic:
+                            Depth: 5
+                            Durability Policy: Volatile
+                            History Policy: Keep Last
+                            Reliability Policy: Reliable
+                            Value: /planning/scenario_planning/lane_driving/behavior_planning/behavior_path_planner/info/avoidance_by_lane_change
+                          Value: false
+                        - Class: rviz_default_plugins/MarkerArray
+                          Enabled: false
+                          Name: Info (LaneChangeLeft)
+                          Namespaces:
+                            {}
+                          Topic:
+                            Depth: 5
+                            Durability Policy: Volatile
+                            History Policy: Keep Last
+                            Reliability Policy: Reliable
+                            Value: /planning/scenario_planning/lane_driving/behavior_planning/behavior_path_planner/info/lane_change_left
+                          Value: false
+                        - Class: rviz_default_plugins/MarkerArray
+                          Enabled: false
+                          Name: Info (LaneChangeRight)
+                          Namespaces:
+                            {}
+                          Topic:
+                            Depth: 5
+                            Durability Policy: Volatile
+                            History Policy: Keep Last
+                            Reliability Policy: Reliable
+                            Value: /planning/scenario_planning/lane_driving/behavior_planning/behavior_path_planner/info/lane_change_right
+                          Value: false
+                        - Class: rviz_default_plugins/MarkerArray
+                          Enabled: false
+                          Name: Info (ExtLaneChangeLeft)
+                          Namespaces:
+                            {}
+                          Topic:
+                            Depth: 5
+                            Durability Policy: Volatile
+                            History Policy: Keep Last
+                            Reliability Policy: Reliable
+                            Value: /planning/scenario_planning/lane_driving/behavior_planning/behavior_path_planner/info/external_request_lane_change_left
+                          Value: false
+                        - Class: rviz_default_plugins/MarkerArray
+                          Enabled: false
+                          Name: Info (ExtLaneChangeRight)
+                          Namespaces:
+                            {}
+                          Topic:
+                            Depth: 5
+                            Durability Policy: Volatile
+                            History Policy: Keep Last
+                            Reliability Policy: Reliable
+                            Value: /planning/scenario_planning/lane_driving/behavior_planning/behavior_path_planner/info/external_request_lane_change_right
+                          Value: false
+                        - Class: rviz_default_plugins/MarkerArray
+                          Enabled: false
+                          Name: Info (GoalPlanner)
+                          Namespaces:
+                            {}
+                          Topic:
+                            Depth: 5
+                            Durability Policy: Volatile
+                            History Policy: Keep Last
+                            Reliability Policy: Reliable
+                            Value: /planning/scenario_planning/lane_driving/behavior_planning/behavior_path_planner/info/goal_planner
+                          Value: false
+                        - Class: rviz_default_plugins/MarkerArray
+                          Enabled: false
+                          Name: Info (StartPlanner)
+                          Namespaces:
+                            {}
+                          Topic:
+                            Depth: 5
+                            Durability Policy: Volatile
+                            History Policy: Keep Last
+                            Reliability Policy: Reliable
+                            Value: /planning/scenario_planning/lane_driving/behavior_planning/behavior_path_planner/info/start_planner
+                          Value: false
+                        - Class: rviz_default_plugins/MarkerArray
+                          Enabled: false
+                          Name: Info (DynamicObstacleAvoidance)
+                          Namespaces:
+                            {}
+                          Topic:
+                            Depth: 5
+                            Durability Policy: Volatile
+                            History Policy: Keep Last
+                            Reliability Policy: Reliable
+                            Value: /planning/scenario_planning/lane_driving/behavior_planning/behavior_path_planner/info/dynamic_obstacle_avoidance
+                          Value: false
+                      Enabled: false
+                      Name: InfoMarker
                   Enabled: true
                   Name: BehaviorPlanning
                 - Class: rviz_common/Group
@@ -1650,6 +2445,9 @@ Visualization Manager:
                         Color: 0; 60; 255
                         Offset: 0
                         Radius: 0.10000000149011612
+                        Value: false
+                      View Text Slope:
+                        Scale: 0.30000001192092896
                         Value: false
                       View Text Velocity:
                         Scale: 0.30000001192092896
@@ -1696,7 +2494,67 @@ Visualization Manager:
                             Durability Policy: Volatile
                             History Policy: Keep Last
                             Reliability Policy: Reliable
-                            Value: /planning/scenario_planning/lane_driving/motion_planning/obstacle_avoidance_planner/debug/virtual_wall
+                            Value: /planning/scenario_planning/lane_driving/motion_planning/obstacle_avoidance_planner/virtual_wall
+                          Value: true
+                        - Class: rviz_default_plugins/MarkerArray
+                          Enabled: true
+                          Name: VirtualWall (ObstacleCruise)
+                          Namespaces:
+                            {}
+                          Topic:
+                            Depth: 5
+                            Durability Policy: Volatile
+                            History Policy: Keep Last
+                            Reliability Policy: Reliable
+                            Value: /planning/scenario_planning/lane_driving/motion_planning/obstacle_cruise_planner/virtual_wall
+                          Value: true
+                        - Class: rviz_default_plugins/MarkerArray
+                          Enabled: true
+                          Name: VirtualWall (MotionVelocitySmoother)
+                          Namespaces:
+                            {}
+                          Topic:
+                            Depth: 5
+                            Durability Policy: Volatile
+                            History Policy: Keep Last
+                            Reliability Policy: Reliable
+                            Value: /planning/scenario_planning/velocity_smoother/virtual_wall
+                          Value: true
+                        - Class: rviz_default_plugins/MarkerArray
+                          Enabled: true
+                          Name: VirtualWall (OutOfLane)
+                          Namespaces:
+                            {}
+                          Topic:
+                            Depth: 5
+                            Durability Policy: Volatile
+                            History Policy: Keep Last
+                            Reliability Policy: Reliable
+                            Value: /planning/scenario_planning/lane_driving/motion_planning/motion_velocity_planner/out_of_lane/virtual_walls
+                          Value: true
+                        - Class: rviz_default_plugins/MarkerArray
+                          Enabled: true
+                          Name: VirtualWall (ObstacleVelocityLimiter)
+                          Namespaces:
+                            {}
+                          Topic:
+                            Depth: 5
+                            Durability Policy: Volatile
+                            History Policy: Keep Last
+                            Reliability Policy: Reliable
+                            Value: /planning/scenario_planning/lane_driving/motion_planning/motion_velocity_planner/obstacle_velocity_limiter/virtual_walls
+                          Value: true
+                        - Class: rviz_default_plugins/MarkerArray
+                          Enabled: true
+                          Name: VirtualWall (DynamicObstacleStop)
+                          Namespaces:
+                            {}
+                          Topic:
+                            Depth: 5
+                            Durability Policy: Volatile
+                            History Policy: Keep Last
+                            Reliability Policy: Reliable
+                            Value: /planning/scenario_planning/lane_driving/motion_planning/motion_velocity_planner/dynamic_obstacle_stop/virtual_walls
                           Value: true
                       Enabled: true
                       Name: VirtualWall
@@ -1755,10 +2613,10 @@ Visualization Manager:
                                 Reliability Policy: Reliable
                                 Value: /planning/scenario_planning/lane_driving/motion_planning/surround_obstacle_checker/debug/footprint_recover_offset
                               Value: false
-                          Enabled: true
+                          Enabled: false
                           Name: SurroundObstacleChecker
                         - Class: rviz_default_plugins/MarkerArray
-                          Enabled: true
+                          Enabled: false
                           Name: ObstacleStop
                           Namespaces:
                             {}
@@ -1768,9 +2626,49 @@ Visualization Manager:
                             History Policy: Keep Last
                             Reliability Policy: Reliable
                             Value: /planning/scenario_planning/lane_driving/motion_planning/obstacle_stop_planner/debug/marker
-                          Value: true
+                          Value: false
+                        - Class: rviz_common/Group
+                          Displays:
+                            - Class: rviz_default_plugins/MarkerArray
+                              Enabled: true
+                              Name: CruiseVirtualWall
+                              Namespaces:
+                                {}
+                              Topic:
+                                Depth: 5
+                                Durability Policy: Volatile
+                                History Policy: Keep Last
+                                Reliability Policy: Reliable
+                                Value: /planning/scenario_planning/lane_driving/motion_planning/obstacle_cruise_planner/debug/cruise/virtual_wall
+                              Value: true
+                            - Class: rviz_default_plugins/MarkerArray
+                              Enabled: true
+                              Name: SlowDownVirtualWall
+                              Namespaces:
+                                {}
+                              Topic:
+                                Depth: 5
+                                Durability Policy: Volatile
+                                History Policy: Keep Last
+                                Reliability Policy: Reliable
+                                Value: /planning/scenario_planning/lane_driving/motion_planning/obstacle_cruise_planner/debug/slow_down/virtual_wall
+                              Value: true
+                            - Class: rviz_default_plugins/MarkerArray
+                              Enabled: true
+                              Name: DebugMarker
+                              Namespaces:
+                                {}
+                              Topic:
+                                Depth: 5
+                                Durability Policy: Volatile
+                                History Policy: Keep Last
+                                Reliability Policy: Reliable
+                                Value: /planning/scenario_planning/lane_driving/motion_planning/obstacle_cruise_planner/debug/marker
+                              Value: true
+                          Enabled: false
+                          Name: ObstacleCruise
                         - Class: rviz_default_plugins/MarkerArray
-                          Enabled: true
+                          Enabled: false
                           Name: ObstacleAvoidance
                           Namespaces:
                             {}
@@ -1780,7 +2678,47 @@ Visualization Manager:
                             History Policy: Keep Last
                             Reliability Policy: Reliable
                             Value: /planning/scenario_planning/lane_driving/motion_planning/obstacle_avoidance_planner/debug/marker
-                          Value: true
+                          Value: false
+                        - Class: rviz_common/Group
+                          Displays:
+                            - Class: rviz_default_plugins/MarkerArray
+                              Enabled: true
+                              Name: OutOfLane
+                              Namespaces:
+                                {}
+                              Topic:
+                                Depth: 5
+                                Durability Policy: Volatile
+                                History Policy: Keep Last
+                                Reliability Policy: Reliable
+                                Value: /planning/scenario_planning/lane_driving/motion_planning/motion_velocity_planner/out_of_lane/debug_markers
+                              Value: true
+                            - Class: rviz_default_plugins/MarkerArray
+                              Enabled: true
+                              Name: ObstacleVelocityLimiter
+                              Namespaces:
+                                {}
+                              Topic:
+                                Depth: 5
+                                Durability Policy: Volatile
+                                History Policy: Keep Last
+                                Reliability Policy: Reliable
+                                Value: /planning/scenario_planning/lane_driving/motion_planning/motion_velocity_planner/obstacle_velocity_limiter/debug_markers
+                              Value: true
+                            - Class: rviz_default_plugins/MarkerArray
+                              Enabled: true
+                              Name: DynamicObstacleStop
+                              Namespaces:
+                                {}
+                              Topic:
+                                Depth: 5
+                                Durability Policy: Volatile
+                                History Policy: Keep Last
+                                Reliability Policy: Reliable
+                                Value: /planning/scenario_planning/lane_driving/motion_planning/motion_velocity_planner/dynamic_obstacle_stop/debug_markers
+                              Value: true
+                          Enabled: false
+                          Name: MotionVelocityPlanner
                       Enabled: false
                       Name: DebugMarker
                   Enabled: true
@@ -1902,21 +2840,21 @@ Visualization Manager:
             Filter size: 10
             History Policy: Keep Last
             Reliability Policy: Reliable
-            Value: /control/trajectory_follower/lateral/predicted_trajectory
+            Value: /control/trajectory_follower/controller_node_exe/debug/predicted_trajectory_in_frenet_coordinate
           Value: true
           View Footprint:
             Alpha: 1
             Color: 230; 230; 50
             Offset from BaseLink: 0
-            Rear Overhang: 1.0299999713897705
+            Rear Overhang: 1.100000023841858
             Value: false
-            Vehicle Length: 4.769999980926514
-            Vehicle Width: 1.8300000429153442
+            Vehicle Length: 4.889999866485596
+            Vehicle Width: 1.8960000276565552
           View Path:
             Alpha: 1
             Color: 255; 255; 255
             Constant Color: true
-            Constant Width: false
+            Constant Width: true
             Value: true
             Width: 0.05000000074505806
           View Point:
@@ -1924,6 +2862,9 @@ Visualization Manager:
             Color: 0; 60; 255
             Offset: 0
             Radius: 0.10000000149011612
+            Value: false
+          View Text Slope:
+            Scale: 0.30000001192092896
             Value: false
           View Text Velocity:
             Scale: 0.30000001192092896
@@ -1934,6 +2875,19 @@ Visualization Manager:
             Constant Color: false
             Scale: 0.30000001192092896
             Value: false
+        - Class: rviz_default_plugins/Marker
+          Enabled: false
+          Name: Stop Reason
+          Namespaces:
+            {}
+          Topic:
+            Depth: 5
+            Durability Policy: Volatile
+            Filter size: 10
+            History Policy: Keep Last
+            Reliability Policy: Reliable
+            Value: /control/trajectory_follower/longitudinal/stop_reason
+          Value: false
         - Class: rviz_default_plugins/MarkerArray
           Enabled: false
           Name: Debug/MPC
@@ -1958,6 +2912,30 @@ Visualization Manager:
             Reliability Policy: Reliable
             Value: /control/trajectory_follower/controller_node_exe/debug/markers
           Value: false
+        - Class: rviz_default_plugins/MarkerArray
+          Enabled: false
+          Name: Debug/AEB
+          Namespaces:
+            {}
+          Topic:
+            Depth: 5
+            Durability Policy: Volatile
+            History Policy: Keep Last
+            Reliability Policy: Reliable
+            Value: /control/autonomous_emergency_braking/debug/markers
+          Value: false
+        - Class: rviz_default_plugins/MarkerArray
+          Enabled: true
+          Name: Info/AEB
+          Namespaces:
+            {}
+          Topic:
+            Depth: 5
+            Durability Policy: Volatile
+            History Policy: Keep Last
+            Reliability Policy: Reliable
+            Value: /control/autonomous_emergency_braking/info/markers
+          Value: true
       Enabled: true
       Name: Control
     - Class: rviz_default_plugins/Image
@@ -1972,11 +2950,11 @@ Visualization Manager:
         Durability Policy: Volatile
         History Policy: Keep Last
         Reliability Policy: Best Effort
-        Value: sensing/camera/traffic_light/image_raw
+        Value: /sensing/camera/traffic_light/image_raw
       Value: true
   Enabled: true
   Global Options:
-    Background Color: 10; 10; 10
+    Background Color: 42; 42; 42
     Fixed Frame: map
     Frame Rate: 30
   Name: root
@@ -2005,6 +2983,13 @@ Visualization Manager:
         History Policy: Keep Last
         Reliability Policy: Reliable
         Value: /planning/mission_planning/goal
+    - Class: tier4_adapi_rviz_plugins::RouteTool
+      Topic:
+        Depth: 5
+        Durability Policy: Volatile
+        History Policy: Keep Last
+        Reliability Policy: Reliable
+        Value: /rviz/routing/rough_goal
     - Acceleration: 0
       Class: rviz_plugins/PedestrianInitialPoseTool
       Interactive: false
@@ -2074,11 +3059,11 @@ Visualization Manager:
       Invert Z Axis: false
       Name: Current View
       Near Clip Distance: 0.009999999776482582
-      Scale: 5.743031978607178
+      Scale: 3.0712084770202637
       Target Frame: viewer
       Value: TopDownOrtho (rviz_default_plugins)
-      X: -106.21235656738281
-      Y: -59.80632781982422
+      X: -114.41345977783203
+      Y: -23.371084213256836
     Saved:
       - Class: rviz_default_plugins/ThirdPersonFollower
         Distance: 18
@@ -2127,9 +3112,7 @@ Window Geometry:
   Hide Right Dock: false
   Image:
     collapsed: false
-  InitialPoseButtonPanel:
-    collapsed: false
-  QMainWindow State: 000000ff00000000fd0000000400000000000002d5000003a2fc0200000010fb0000001200530065006c0065006300740069006f006e00000001e10000009b0000005c00fffffffb000000120056006900650077007300200054006f006f02000001df000002110000018500000122fb000000200054006f006f006c002000500072006f0070006500720074006900650073003203000002880000011d000002210000017afb000000100044006900730070006c006100790073000000003b000000ef000000c700fffffffc00000110000000bb0000000000fffffffaffffffff0100000002fb0000000a0056006900650077007300000000000000033c0000010000fffffffb0000001e0054006f006f006c002000500072006f00700065007200740069006500730000000000ffffffff0000008c00fffffffb00000024004100750074006f00770061007200650053007400610074006500500061006e0065006c010000003b0000015c0000015c00fffffffb0000000a0049006d006100670065010000019d000001f10000002800fffffffb0000002000730065006c0065006300740069006f006e00200062007500660066006500720200000138000000aa0000023a00000294fb00000014005700690064006500530074006500720065006f02000000e6000000d2000003ee0000030bfb0000000c004b0069006e0065006300740200000186000001060000030c00000261fb0000000c00430061006d0065007200610100000682000000eb0000000000000000fb0000000a0049006d0061006700650100000505000002680000000000000000fb0000002c0049006e0069007400690061006c0050006f007300650042007500740074006f006e00500061006e0065006c000000068f000000de0000007100fffffffb0000002c0049006e0069007400690061006c0050006f007300650042007500740074006f006e00500061006e0065006c000000068f000000de0000000000000000fb00000030005200650063006f0067006e006900740069006f006e0052006500730075006c0074004f006e0049006d006100670065000000031c0000007c0000002800fffffffb0000002a004100750074006f0077006100720065004400610074006500540069006d006500500061006e0065006c0100000394000000490000003f00ffffff000000010000015f000006fffc0200000002fb0000001e0054006f006f006c002000500072006f00700065007200740069006500730100000041000000780000000000000000fb0000001200530065006c0065006300740069006f006e010000025a000000b200000000000000000000000200000e7a0000005afc0100000001fb0000000a00560069006500770073030000004e00000080000002e1000001970000000300000e7a0000005afc0100000002fb0000000800540069006d0065010000000000000e7a0000000000000000fb0000000800540069006d006501000000000000045000000000000000000000045b000003a200000004000000040000000800000008fc0000000100000002000000010000000a0054006f006f006c00730100000000ffffffff0000000000000000
+  QMainWindow State: 000000ff00000000fd0000000400000000000001ee000003a2fc020000000ffb0000001200530065006c0065006300740069006f006e00000001e10000009b0000005c00fffffffb000000120056006900650077007300200054006f006f02000001df000002110000018500000122fb000000200054006f006f006c002000500072006f0070006500720074006900650073003203000002880000011d000002210000017afb00000024004100750074006f00770061007200650053007400610074006500500061006e0065006c010000003b000001d90000006e00fffffffb0000002000730065006c0065006300740069006f006e00200062007500660066006500720200000138000000aa0000023a00000294fb00000014005700690064006500530074006500720065006f02000000e6000000d2000003ee0000030bfb0000000c004b0069006e0065006300740200000186000001060000030c00000261fb0000000c00430061006d0065007200610100000682000000eb0000000000000000fb0000000a0049006d006100670065010000021a000001c30000002800fffffffb0000002c0049006e0069007400690061006c0050006f007300650042007500740074006f006e00500061006e0065006c000000068f000000de0000000000000000fb0000002c0049006e0069007400690061006c0050006f007300650042007500740074006f006e00500061006e0065006c000000068f000000de0000000000000000fb00000030005200650063006f0067006e006900740069006f006e0052006500730075006c0074004f006e0049006d00610067006500000001c50000016a0000002800fffffffb0000002a004100750074006f0077006100720065004400610074006500540069006d006500500061006e0065006c0000000332000000720000003f00fffffffb000000240050006f0069006e00740063006c006f00750064004f006e00430061006d006500720061000000039d000000560000000000000000fb0000000a0049006d00610067006501000002c600000117000000000000000000000001000001ab000003a2fc0200000004fb000000100044006900730070006c006100790073010000003b00000142000000c700fffffffc000001830000025a000000bb0100001afa000000000100000002fb0000000a0056006900650077007301000005d5000001ab0000010000fffffffb0000001e0054006f006f006c002000500072006f00700065007200740069006500730100000000ffffffff0000008c00fffffffb0000001e0054006f006f006c002000500072006f00700065007200740069006500730100000041000000780000000000000000fb0000001200530065006c0065006300740069006f006e010000025a000000b200000000000000000000000200000e7a0000005afc0100000001fb0000000a00560069006500770073030000004e00000080000002e1000001970000000300000e7a0000005afc0100000002fb0000000800540069006d0065010000000000000e7a0000000000000000fb0000000800540069006d0065010000000000000450000000000000000000000395000003a200000004000000040000000800000008fc0000000100000002000000010000000a0054006f006f006c00730100000000ffffffff0000000000000000
   RecognitionResultOnImage:
     collapsed: false
   Selection:
@@ -2138,6 +3121,6 @@ Window Geometry:
     collapsed: false
   Views:
     collapsed: false
-  Width: 1846
-  X: 74
-  Y: 27
+  Width: 1850
+  X: 469
+  Y: 1467


### PR DESCRIPTION
1. Since CUDA-related packages are broken since 2024/09/05, we set the Autoware version to 2024/09/03.
2. When preparing Autoware, it will build Autoware models first. It avoids the initialization delay when launching Autoware.
3. Users can set the model they want in env.sh