### PR TITLE
Use new map which has traffic_light information

### DIFF
--- a/script/download_map.sh
+++ b/script/download_map.sh
@@ -13,7 +13,7 @@ fi
 
 if [ ! -f "$MAP_PATH/lanelet2_map.osm" ] || [ ! -f "$MAP_PATH/pointcloud_map.pcd" ] || [ ! -f "$MAP_PATH/map_projector_info.yaml" ]; then
     echo "Download map from Internet..."
-    gdown --fuzzy -O $MAP_PATH/lanelet2_map.osm https://drive.google.com/file/d/1vm9SvalJe7Bc9sh_8jK-0cPulVAov5uD/view
+    gdown --fuzzy -O $MAP_PATH/lanelet2_map.osm https://drive.google.com/file/d/1CMfWin62qIEqQbcIQ6UfplztZDjMBKD6/view
     gdown --fuzzy -O $MAP_PATH/pointcloud_map.pcd https://drive.google.com/file/d/1MvJlfjkw3LWFUs5hdE_KQ2_CQTusU8UN/view
     gdown --fuzzy -O $MAP_PATH/map_projector_info.yaml https://drive.google.com/file/d/1h1me3TXSoTBL86S94QKlkwSpwUeZXv2J/view
     echo "Download complete"


### PR DESCRIPTION
Download new vector map, which has traffic light information.
Since traffic_light detection module doesn't work now, we set is_simulation to be true to avoid keeping stop at the traffic light line.