### PR TITLE
Update docs about Prerequisites and Build

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -10,6 +10,7 @@
 prepare_bridge:
 	# Get code
 	git submodule update --init --recursive
+	sudo apt update
 	# Install rmw_zenoh
 	./script/setup/build_zenoh.sh
 	# Install dependencies

--- a/docs/build.rst
+++ b/docs/build.rst
@@ -22,6 +22,34 @@ Build the container for Carla bridge
     make prepare_bridge
     make build_bridge
 
+.. note::
+    **Troubleshooting:**
+
+    1. If you encounter an error message indicating that `cargo` is not installed during `make prepare_bridge`, try running the following command to update the package list and then rerun the build:
+    
+        .. code-block:: bash
+
+            sudo apt update
+
+    2. If an error occurs during the `ros install` process, run the following command to update the ROS dependencies before retrying:
+    
+        .. code-block:: bash
+
+            rosdep update
+
+    3. During compilation, some packages may fail to compile. You can rerun the build command until all packages compile successfully. If some packages still fail after several attempts, please report an issue.
+
+    4. If `python3.8.10` cannot be installed by `pyenv`, you can install and configure it using `deadsnakes`. Run the following commands to install Python 3.8.10:
+    
+        .. code-block:: bash
+
+            sudo add-apt-repository ppa:deadsnakes/ppa
+            sudo apt update
+            sudo apt install python3.8 python3.8-dev python3.8-venv
+            sudo ln -sf /usr/bin/python3.8 /usr/bin/python
+            sudo curl https://bootstrap.pypa.io/pip/3.8/get-pip.py -o get-pip.py && python get-pip.py
+
+
 Build the container for Zenoh+Autoware
 --------------------------------------
 

--- a/docs/build.rst
+++ b/docs/build.rst
@@ -22,21 +22,6 @@ Build the container for Carla bridge
     make prepare_bridge
     make build_bridge
 
-.. note::
-    **Troubleshooting:**
-
-    1. During compilation, some packages may fail to compile. You can rerun the build command until all packages compile successfully. If some packages still fail after several attempts, please report an issue.
-
-    2. If `python3.8.10` cannot be installed by `pyenv`, you can install and configure it using `deadsnakes`. Run the following commands to install Python 3.8.10:
-    
-        .. code-block:: bash
-
-            sudo add-apt-repository ppa:deadsnakes/ppa
-            sudo apt update
-            sudo apt install python3.8 python3.8-dev python3.8-venv
-            sudo ln -sf /usr/bin/python3.8 /usr/bin/python
-            sudo curl https://bootstrap.pypa.io/pip/3.8/get-pip.py -o get-pip.py && python get-pip.py
-
 
 Build the container for Zenoh+Autoware
 --------------------------------------

--- a/docs/build.rst
+++ b/docs/build.rst
@@ -25,21 +25,9 @@ Build the container for Carla bridge
 .. note::
     **Troubleshooting:**
 
-    1. If you encounter an error message indicating that `cargo` is not installed during `make prepare_bridge`, try running the following command to update the package list and then rerun the build:
-    
-        .. code-block:: bash
+    1. During compilation, some packages may fail to compile. You can rerun the build command until all packages compile successfully. If some packages still fail after several attempts, please report an issue.
 
-            sudo apt update
-
-    2. If an error occurs during the `ros install` process, run the following command to update the ROS dependencies before retrying:
-    
-        .. code-block:: bash
-
-            rosdep update
-
-    3. During compilation, some packages may fail to compile. You can rerun the build command until all packages compile successfully. If some packages still fail after several attempts, please report an issue.
-
-    4. If `python3.8.10` cannot be installed by `pyenv`, you can install and configure it using `deadsnakes`. Run the following commands to install Python 3.8.10:
+    2. If `python3.8.10` cannot be installed by `pyenv`, you can install and configure it using `deadsnakes`. Run the following commands to install Python 3.8.10:
     
         .. code-block:: bash
 

--- a/docs/faq.rst
+++ b/docs/faq.rst
@@ -48,7 +48,7 @@ FAQ
 
     .. code-block:: bash
 
-        pip install sphinx
+        pip install -r docs/requirements.txt
         sphinx-build -a docs /tmp/mydocs
         xdg-open /tmp/mydocs/index.html
 

--- a/docs/prerequisites.rst
+++ b/docs/prerequisites.rst
@@ -4,7 +4,7 @@ Prerequisites
 Make sure you meet the following system requirements
 
 * Ubuntu 22.04
-* Carla 0.9.14
+* Carla 0.9.14 - `download <https://github.com/carla-simulator/carla/releases/tag/0.9.14>`_
 
 Packages Installation
 ---------------------
@@ -14,3 +14,35 @@ Install rocker for containers
 ..  code-block:: bash
 
     sudo apt install docker.io python3-rocker
+
+.. note::
+    `python3-rocker` is provided by the ROS 2 Humble release. 
+    To install it, you should first configure Ubuntu for ROS 2 Humble. 
+    You can refer to the official documentation for installation steps:
+    https://docs.ros.org/en/humble/Installation/Ubuntu-Install-Debs.html.
+
+    The following steps will guide you in configuring ROS 2 Humble:
+
+1. Configure ROS 2 repositories for your system:
+
+    .. code-block:: bash
+
+        sudo apt install software-properties-common
+        sudo add-apt-repository universe
+        sudo apt update && sudo apt install curl -y
+        export ROS_APT_SOURCE_VERSION=$(curl -s https://api.github.com/repos/ros-infrastructure/ros-apt-source/releases/latest | grep -F "tag_name" | awk -F\" '{print $4}')
+        curl -L -o /tmp/ros2-apt-source.deb "https://github.com/ros-infrastructure/ros-apt-source/releases/download/${ROS_APT_SOURCE_VERSION}/ros2-apt-source_${ROS_APT_SOURCE_VERSION}.$(. /etc/os-release && echo $VERSION_CODENAME)_all.deb"
+        sudo dpkg -i /tmp/ros2-apt-source.deb
+
+2. Update, upgrade, and install ROS 2 Humble:
+
+    .. code-block:: bash
+
+        sudo apt update
+        sudo apt upgrade
+        sudo apt install ros-humble-desktop
+3. Then, you can install `python3-rocker`:
+
+    .. code-block:: bash
+
+        sudo apt install python3-rocker

--- a/docs/prerequisites.rst
+++ b/docs/prerequisites.rst
@@ -16,14 +16,12 @@ Install rocker for containers
     sudo apt install docker.io python3-rocker
 
 .. note::
-    `python3-rocker` is provided by the ROS 2 Humble release. 
-    To install it, you should first configure Ubuntu for ROS 2 Humble. 
+    `python3-rocker` is provided by the ROS 2. 
+    To install it, you should first configure Ubuntu for ROS 2 repositories. 
     You can refer to the official documentation for installation steps:
     https://docs.ros.org/en/humble/Installation/Ubuntu-Install-Debs.html.
 
-    The following steps will guide you in configuring ROS 2 Humble:
-
-1. Configure ROS 2 repositories for your system:
+    The following steps will guide you in configuring ROS 2 repositories and install `python3-rocker`:
 
     .. code-block:: bash
 
@@ -33,16 +31,5 @@ Install rocker for containers
         export ROS_APT_SOURCE_VERSION=$(curl -s https://api.github.com/repos/ros-infrastructure/ros-apt-source/releases/latest | grep -F "tag_name" | awk -F\" '{print $4}')
         curl -L -o /tmp/ros2-apt-source.deb "https://github.com/ros-infrastructure/ros-apt-source/releases/download/${ROS_APT_SOURCE_VERSION}/ros2-apt-source_${ROS_APT_SOURCE_VERSION}.$(. /etc/os-release && echo $VERSION_CODENAME)_all.deb"
         sudo dpkg -i /tmp/ros2-apt-source.deb
-
-2. Update, upgrade, and install ROS 2 Humble:
-
-    .. code-block:: bash
-
         sudo apt update
-        sudo apt upgrade
-        sudo apt install ros-humble-desktop
-3. Then, you can install `python3-rocker`:
-
-    .. code-block:: bash
-
         sudo apt install python3-rocker

--- a/docs/prerequisites.rst
+++ b/docs/prerequisites.rst
@@ -4,7 +4,7 @@ Prerequisites
 Make sure you meet the following system requirements
 
 * Ubuntu 22.04
-* Carla 0.9.14 - `download <https://github.com/carla-simulator/carla/releases/tag/0.9.14>`_
+* `Carla 0.9.14 <https://github.com/carla-simulator/carla/releases/tag/0.9.14>`_
 
 Packages Installation
 ---------------------

--- a/script/setup/build_zenoh.sh
+++ b/script/setup/build_zenoh.sh
@@ -7,6 +7,7 @@ if [ ! -d "rmw_zenoh_ws" ]; then
     cd rmw_zenoh || exit
     git checkout 65ded05
     cd ../.. || exit
+    rosdep update
     rosdep install --from-paths src --ignore-src --rosdistro humble -y
     cd .. || exit
 fi


### PR DESCRIPTION
Thanks for all your amazing work! I have made the following updates to the documentation:

1. For the documentation build, changed `pip install sphinx` -> `pip install -r docs/requirements.txt`.
2. In the prerequisites section, added a link to download `CARAL 0.9.14`, and provided a a step-by-step guide for configuring ROS 2 Humble to install `python3-rocker`.
3. For the bridge build, troubleshooting steps (based on issues I encountered in my environment, which others may also face):

-    The command `rosdep install --from-paths src --ignore-src --rosdistro humble -y` in `script/setup/build_zenoh.sh` may fail with a message indicating that `cargo` is not install, or requiring a `rosdep update`. Running `sudo apt update` followed by `rosdep update` should resolve this issue.

- The command `pyenv install -v 3.8.10` failed to build Python from source in my environment. I resolved this by installing Python 3.8.10 from `deadsnakes`. As of now, Autoware and the bridge are successfully connected. If `autoware_carla_launch` requires features that need to be built from source, please let me know.