### PR TITLE
Fix: remove `--fuzzy` CLI flag of `gdown`

### DIFF
--- a/script/setup/download_map.sh
+++ b/script/setup/download_map.sh
@@ -13,8 +13,8 @@ fi
 
 if [ ! -f "$MAP_PATH/lanelet2_map.osm" ] || [ ! -f "$MAP_PATH/pointcloud_map.pcd" ] || [ ! -f "$MAP_PATH/map_projector_info.yaml" ]; then
     echo "Download map from Internet..."
-    gdown --fuzzy -O $MAP_PATH/lanelet2_map.osm https://drive.google.com/file/d/1eTuRuXWCLHzunwD11zgDahIjVrKLpv__/view
-    gdown --fuzzy -O $MAP_PATH/pointcloud_map.pcd https://drive.google.com/file/d/1MvJlfjkw3LWFUs5hdE_KQ2_CQTusU8UN/view
-    gdown --fuzzy -O $MAP_PATH/map_projector_info.yaml https://drive.google.com/file/d/1Nl3NsDADGQliMgjk7_En5Fc14ja7sIZF/view
+    gdown -O $MAP_PATH/lanelet2_map.osm https://drive.google.com/file/d/1eTuRuXWCLHzunwD11zgDahIjVrKLpv__/view
+    gdown -O $MAP_PATH/pointcloud_map.pcd https://drive.google.com/file/d/1MvJlfjkw3LWFUs5hdE_KQ2_CQTusU8UN/view
+    gdown -O $MAP_PATH/map_projector_info.yaml https://drive.google.com/file/d/1Nl3NsDADGQliMgjk7_En5Fc14ja7sIZF/view
     echo "Download complete"
 fi


### PR DESCRIPTION
In version 6.0.0 of `gdown`, the `fuzzy` CLI flag has been removed. See https://github.com/wkentaro/gdown/releases/tag/v6.0.0