### PR TITLE
feat(launch): engage REMOTE via vehicle_cmd_gate, drop manual relays

### DIFF
--- a/config/zenoh-bridge-ros2dds-conf.json5
+++ b/config/zenoh-bridge-ros2dds-conf.json5
@@ -62,7 +62,7 @@
             "/api/routing/set_route_points"
         ],
         service_clients: [
-            "/all_ignore"
+            "/control/control_mode_request"
         ],
         action_servers: [
             "/all_ignore"

--- a/src/autoware_carla_launch/launch/autoware_zenoh.launch.xml
+++ b/src/autoware_carla_launch/launch/autoware_zenoh.launch.xml
@@ -92,9 +92,4 @@
     </node>
 	</group>
 
-  <!-- Relay for manual control -->
-  <group if="$(var manual_control)">
-    <node pkg="topic_tools" exec="relay" name="relay_control_cmd" args="external/selected/control_cmd control/command/control_cmd" output="screen"/>
-    <node pkg="topic_tools" exec="relay" name="relay_gear_cmd" args="external/selected/gear_cmd control/command/gear_cmd" output="screen"/>
-  </group>
 </launch>


### PR DESCRIPTION
## Summary

Restore the standard Autoware MUX architecture: route REMOTE engage through `vehicle_cmd_gate` and drop the manual `topic_tools/relay` nodes that were publishing in parallel onto `/control/command/{control,gear}_cmd`. With the bridge now serving `control_mode_request`, the gate engages cleanly and forwards `external/selected/...` itself.

## Changes

- `config/zenoh-bridge-ros2dds-conf.json5` — add `/control/control_mode_request` to `service_clients` so the bridge proxies the engage handshake.
- `src/autoware_carla_launch/launch/autoware_zenoh.launch.xml` — remove `relay_control_cmd` and `relay_gear_cmd`. These relays raced `vehicle_cmd_gate` whenever the gate wasn't engaged: the gate emitted a stop command while the relay forwarded the operator's intent, producing alternating accelerate/decelerate output to downstream consumers.
- `external/zenoh_carla_bridge` — bump submodule pin to the version that serves `control_mode_request`.

## Dependency

Depends on `evshary/zenoh_carla_bridge#<feat/control-mode-request>` landing first. Without the bridge service, the gate's engage call would still time out and this launch change alone wouldn't help.