### PR TITLE
feat(launch): bridge /initialpose for sim-aware actor teleport

### DIFF
--- a/config/zenoh-bridge-ros2dds-conf.json5
+++ b/config/zenoh-bridge-ros2dds-conf.json5
@@ -24,6 +24,7 @@
             "/control/current_gate_mode",
             "/control/command/turn_indicators_cmd",
             "/control/command/hazard_lights_cmd",
+            "/initialpose",
 
             // Used by FMS
             "/api/external/get/vehicle/status",


### PR DESCRIPTION
## Summary

Whitelist `/initialpose` through `zenoh-bridge-ros2dds` so an `/initialpose` publisher on the Autoware side reaches the Carla actor via the `zenoh_carla_bridge` subscriber.

## Preview the effect on `fms`

<img width="1080" height="537" alt="output_compress" src="https://github.com/user-attachments/assets/c74da81a-1ffd-4706-a681-d6ca39822ee1" />

## Changes

- `config/zenoh-bridge-ros2dds-conf.json5` — add `/initialpose` to the bridge's `subscribers` list.
- `external/zenoh_carla_bridge` — bump submodule pin to the version with the matching `/initialpose` subscriber.

## Dependency

Depends on `evshary/zenoh_carla_bridge#<feat/initialpose-teleport>` landing first.