### PR TITLE
Re-land: engage REMOTE via vehicle_cmd_gate + add vehicle_interface_shim

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -24,3 +24,7 @@
 \#*#
 *.swp
 *.swo
+
+# Python bytecode (vehicle_interface_shim.py)
+__pycache__/
+*.pyc

--- a/config/zenoh-bridge-ros2dds-conf.json5
+++ b/config/zenoh-bridge-ros2dds-conf.json5
@@ -62,7 +62,7 @@
             "/api/routing/set_route_points"
         ],
         service_clients: [
-            "/all_ignore"
+            "/control/control_mode_request"
         ],
         action_servers: [
             "/all_ignore"

--- a/config/zenoh-bridge-ros2dds-conf.json5
+++ b/config/zenoh-bridge-ros2dds-conf.json5
@@ -36,7 +36,6 @@
             "/vehicle/status/actuation_status",
             "/vehicle/status/velocity_status",
             "/vehicle/status/steering_status",
-            "/vehicle/status/control_mode",
             "/vehicle/status/gear_status",
             "/vehicle/status/turn_indicators_status",
             "/vehicle/status/hazard_lights_status",
@@ -62,7 +61,7 @@
             "/api/routing/set_route_points"
         ],
         service_clients: [
-            "/control/control_mode_request"
+            "/all_ignore"
         ],
         action_servers: [
             "/all_ignore"

--- a/src/autoware_carla_launch/CMakeLists.txt
+++ b/src/autoware_carla_launch/CMakeLists.txt
@@ -32,4 +32,9 @@ install(DIRECTORY
   DESTINATION share/${PROJECT_NAME}/
 )
 
+install(PROGRAMS
+  scripts/vehicle_interface_shim.py
+  DESTINATION lib/${PROJECT_NAME}
+)
+
 ament_package()

--- a/src/autoware_carla_launch/launch/autoware_zenoh.launch.xml
+++ b/src/autoware_carla_launch/launch/autoware_zenoh.launch.xml
@@ -77,6 +77,12 @@
   <!-- CARLA -->
   <group if="$(var carla_interface)">
 
+    <!-- Carla vehicle-interface shim: answers /control/control_mode_request
+         (the engage handshake) and republishes /vehicle/status/control_mode.
+         simple_planning_simulator does this for the built-in sim; with Carla
+         the role moves here so zenoh_carla_bridge stays pure data-transport. -->
+    <node pkg="autoware_carla_launch" exec="vehicle_interface_shim.py" name="vehicle_interface_shim" output="screen"/>
+
     <!-- Converts Autoware's Ackermann control command into actuation command for CARLA vehicles -->
     <arg name="input_control_cmd" default="/control/command/control_cmd"/>
     <arg name="input_odometry" default="/localization/kinematic_state"/>

--- a/src/autoware_carla_launch/launch/autoware_zenoh.launch.xml
+++ b/src/autoware_carla_launch/launch/autoware_zenoh.launch.xml
@@ -92,9 +92,4 @@
     </node>
 	</group>
 
-  <!-- Relay for manual control -->
-  <group if="$(var manual_control)">
-    <node pkg="topic_tools" exec="relay" name="relay_control_cmd" args="external/selected/control_cmd control/command/control_cmd" output="screen"/>
-    <node pkg="topic_tools" exec="relay" name="relay_gear_cmd" args="external/selected/gear_cmd control/command/gear_cmd" output="screen"/>
-  </group>
 </launch>

--- a/src/autoware_carla_launch/package.xml
+++ b/src/autoware_carla_launch/package.xml
@@ -10,6 +10,8 @@
   <buildtool_depend>ament_cmake</buildtool_depend>
 
   <depend>moveit_msgs</depend>
+  <exec_depend>rclpy</exec_depend>
+  <exec_depend>autoware_vehicle_msgs</exec_depend>
   <test_depend>ament_lint_auto</test_depend>
   <test_depend>ament_lint_common</test_depend>
 

--- a/src/autoware_carla_launch/scripts/vehicle_interface_shim.py
+++ b/src/autoware_carla_launch/scripts/vehicle_interface_shim.py
@@ -1,0 +1,56 @@
+#!/usr/bin/env python3
+# Carla vehicle-interface stand-in: answers /control/control_mode_request and
+# publishes /vehicle/status/control_mode (simple_planning_simulator's job in
+# the built-in sim). Runs in the Autoware DDS domain so engage needs no Zenoh
+# hop; zenoh_carla_bridge stays pure data-transport.
+
+import rclpy
+from rclpy.clock import Clock, ClockType
+from rclpy.node import Node
+
+from autoware_vehicle_msgs.msg import ControlModeReport
+from autoware_vehicle_msgs.srv import ControlModeCommand
+
+
+class VehicleInterfaceShim(Node):
+    def __init__(self):
+        super().__init__("vehicle_interface_shim")
+        self._mode = ControlModeReport.MANUAL
+        self._srv = self.create_service(
+            ControlModeCommand, "/control/control_mode_request", self._on_request
+        )
+        self._pub = self.create_publisher(
+            ControlModeReport, "/vehicle/status/control_mode", 1
+        )
+        # Wall clock: use_sim_time is injected globally but this node has no
+        # /clock source, so a node-clock timer would stall when /clock does.
+        self.create_timer(
+            0.1, self._publish, clock=Clock(clock_type=ClockType.STEADY_TIME)
+        )
+
+    def _on_request(self, req, res):
+        res.success = True  # reply, then latch the accepted mode
+        self._mode = req.mode
+        return res
+
+    def _publish(self):
+        msg = ControlModeReport()
+        msg.stamp = self.get_clock().now().to_msg()
+        msg.mode = self._mode
+        self._pub.publish(msg)
+
+
+def main():
+    rclpy.init()
+    node = VehicleInterfaceShim()
+    try:
+        rclpy.spin(node)
+    except KeyboardInterrupt:
+        pass
+    finally:
+        node.destroy_node()
+        rclpy.shutdown()
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary

Re-lands the relay-removal from #193 (reverted by #196 pending discussion),
this time together with a small `vehicle_interface_shim` node that makes the
engage handshake actually complete — so dropping the manual relays is safe.

## Background

#193 dropped the `topic_tools/relay` nodes and routed REMOTE engage through
`vehicle_cmd_gate`, assuming the bridge would serve
`/control/control_mode_request`. That coupling was fragile (Zenoh hop, bridge
tracking control-mode state) and #193 was reverted for discussion. The
handshake now lives in a node co-located with Autoware instead.

## Changes

- Re-apply #193: remove the two `manual_control` `topic_tools/relay` nodes
  (a parallel publisher on `/control/command/{control,gear}_cmd` racing the
  gate); `service_clients` stays `"/all_ignore"`.
- Add `vehicle_interface_shim` (rclpy): answers
  `/control/control_mode_request` (replies success, latches the accepted
  mode) and republishes `/vehicle/status/control_mode` at 10 Hz, in the
  Autoware DDS domain — no Zenoh hop. This is what `simple_planning_simulator`
  does for the built-in sim; with Carla nothing did, so engage timed out and
  the gate stayed paused.
- Drop `/vehicle/status/control_mode` from the bridge allow-list (the shim
  owns it; avoids a two-publisher conflict).

## Verification

End-to-end in Carla: `change_to_remote` + `enable_autoware_control` complete,
`/vehicle/status/control_mode` latches AUTONOMOUS, single publisher on
`/control/command/control_cmd`, vehicle drivable.