### PR TITLE
Replace ROS v2x_light with standalone Zenoh Python module

### DIFF
--- a/config/RMW_ZENOH_ROUTER_V1_CONFIG.json5
+++ b/config/RMW_ZENOH_ROUTER_V1_CONFIG.json5
@@ -522,7 +522,7 @@
           "v1/@ros2_lv/**",
 
           // Used by FMS
-          "v1/*/api/vehicle/kinematics/**",
+          "v1/*/api/vehicle/kinematics/**", // v2x also
           "v1/*/api/vehicle/status/**",
           "v1/*/api/routing/route/**",
           "v1/*/system/system_monitor/cpu_monitor/cpu_usage/**",
@@ -533,6 +533,10 @@
           "v1/*/api/operation_mode/change_to_remote/**",
           "v1/*/api/routing/clear_route/**",
           "v1/*/api/routing/set_route_points/**",
+
+          // Used by v2x (ROS topics via rmw_zenoh)
+          "v1/*/planning/scenario_planning/lane_driving/behavior_planning/path_with_lane_id/**",
+          "v1/*/perception/traffic_light_recognition/traffic_signals/**",
         ]
       },
     ],

--- a/config/RMW_ZENOH_ROUTER_V2_CONFIG.json5
+++ b/config/RMW_ZENOH_ROUTER_V2_CONFIG.json5
@@ -522,7 +522,7 @@
           "v2/@ros2_lv/**",
 
           // Used by FMS
-          "v2/*/api/vehicle/kinematics/**",
+          "v2/*/api/vehicle/kinematics/**", // v2x also
           "v2/*/api/vehicle/status/**",
           "v2/*/api/routing/route/**",
           "v2/*/system/system_monitor/cpu_monitor/cpu_usage/**",
@@ -533,6 +533,10 @@
           "v2/*/api/operation_mode/change_to_remote/**",
           "v2/*/api/routing/clear_route/**",
           "v2/*/api/routing/set_route_points/**",
+
+          // Used by v2x (ROS topics via rmw_zenoh)
+          "v2/*/planning/scenario_planning/lane_driving/behavior_planning/path_with_lane_id/**",
+          "v2/*/perception/traffic_light_recognition/traffic_signals/**",
         ]
       },
     ],

--- a/config/zenoh-bridge-ros2dds-conf.json5
+++ b/config/zenoh-bridge-ros2dds-conf.json5
@@ -26,10 +26,13 @@
             "/control/command/hazard_lights_cmd",
 
             // Used by FMS
-            "/api/vehicle/kinematics",
+            "/api/vehicle/kinematics", // v2x also
             "/api/vehicle/status",
             "/api/routing/route",
             "/system/system_monitor/cpu_monitor/cpu_usage",
+
+            // Used by v2x
+            "/planning/scenario_planning/lane_driving/behavior_planning/path_with_lane_id",
         ],
         subscribers: [
             // Receive from bridge
@@ -51,7 +54,10 @@
             "/external/selected/control_cmd",
             "/external/selected/gear_cmd",
             "/control/gate_mode_cmd",
-            "/sensing/camera/.*"
+            "/sensing/camera/.*",
+
+            // Used by v2x_light
+            "/perception/traffic_light_recognition/traffic_signals"
         ],
         service_servers: [
             // Used by FMS

--- a/docs/scenarios/v2x.rst
+++ b/docs/scenarios/v2x.rst
@@ -36,22 +36,6 @@ Field meanings:
 * ``autoware_traffic_light`` — Traffic Light ID.
 * ``traffic_light_position`` — ``(x, y)`` in the Autoware map frame.
 
-Build V2X module
-----------------
-
-* Enter into docker
-
-..  code-block:: bash
-
-    ./container/run-autoware-docker.sh
-
-* Build the code
-
-.. code-block:: bash
-
-   cd autoware_carla_launch/external/zenoh_autoware_v2x
-   colcon build --symlink-install
-
 Running single vehicle scenario
 -------------------------------
 

--- a/env.sh
+++ b/env.sh
@@ -9,15 +9,12 @@ if [ -f /opt/zenoh-carla-bridge ]; then   # Python agent & zenoh_carla_bridge
     # Export Carla simulator IP
     export CARLA_SIMULATOR_IP=127.0.0.1
 
-    # uv path (Only needed while using docker)
+    # pyenv path (Only needed while using docker)
     if [ -f /.dockerenv ]; then
         PYENV_PATH=${AUTOWARE_CARLA_ROOT}/pyenv
-        UV_PATH=${AUTOWARE_CARLA_ROOT}/uv
 
         export PYENV_ROOT="${PYENV_PATH}"
         export PATH="${PYENV_ROOT}/bin:$PATH"
-        export UV_INSTALL_DIR=${UV_PATH}/bin
-        export PATH="${UV_PATH}/bin:$PATH"
     fi
 
     # Environmental variables to build carla-sys
@@ -73,11 +70,13 @@ export LIDAR_DETECTION_MODEL="centerpoint"
 # It is used when LIDAR_DETECTION_MODEL is set as "centerpoint"
 export CENTERPOINT_MODEL_NAME="centerpoint_tiny"
 
-# Rust path (Only needed while using docker)
+# Rust & uv path (Only needed while using docker)
 if [ -f /.dockerenv ]; then
     RUST_PATH=${AUTOWARE_CARLA_ROOT}/rust
+    UV_PATH=${AUTOWARE_CARLA_ROOT}/uv
 
     export RUSTUP_HOME=${RUST_PATH}
     export CARGO_HOME=${RUST_PATH}
-    export PATH="${RUST_PATH}/bin:$PATH"
+    export UV_INSTALL_DIR=${UV_PATH}/bin
+    export PATH="${RUST_PATH}/bin:${UV_PATH}/bin:$PATH"
 fi

--- a/script/autoware_rmw_zenoh/run-autoware-v2x-with-rmw_zenoh.sh
+++ b/script/autoware_rmw_zenoh/run-autoware-v2x-with-rmw_zenoh.sh
@@ -18,8 +18,7 @@ export ZENOH_CONFIG_OVERRIDE="namespace=\"${VEHICLE_NAME}\""
 # export ZENOH_SHM_ALLOC_SIZE=$((128 * 1024 * 1024))
 # export ZENOH_SHM_MESSAGE_SIZE_THRESHOLD=1024
 
-# Source v2x_light overlay so ros2 run can find it in the parallel job below
-source external/zenoh_autoware_v2x/install/setup.bash
+V2X_PATH=${AUTOWARE_CARLA_ROOT}/external/zenoh_autoware_v2x/
 
 # Log folder
 LOG_PATH=autoware_log/`date '+%Y-%m-%d_%H:%M:%S'`/
@@ -31,5 +30,7 @@ parallel --verbose --lb ::: \
             2>&1 | tee ${LOG_PATH}/autoware.log" \
     "RUST_LOG=debug ros2 run rmw_zenoh_cpp rmw_zenohd \
     	    2>&1 | tee ${LOG_PATH}/rmw_zenohd.log" \
-    "sleep 5 && ros2 run v2x_light v2x_light -- -v ${VEHICLE_NAME} --map-info external/zenoh_autoware_v2x/map_info.json \
+    "sleep 5 && uv run --project ${V2X_PATH} ${V2X_PATH}/v2x_light/main.py \
+            --rmw_zenoh -v ${VEHICLE_NAME} --map-info ${V2X_PATH}/map_info.json \
+            -e tcp/127.0.0.1:7447 -e tcp/172.17.0.1:7447 \
             2>&1 | tee ${LOG_PATH}/v2x_light.log"

--- a/script/autoware_ros2dds/run-autoware-v2x.sh
+++ b/script/autoware_ros2dds/run-autoware-v2x.sh
@@ -13,8 +13,7 @@ if [[ ${ZENOH_FMS_IP_PORT} != *":"* ]]; then
     export ZENOH_FMS_IP_PORT="${ZENOH_FMS_IP_PORT}:7887"
 fi
 
-# Source v2x_light overlay so ros2 run can find it in the parallel job below
-source external/zenoh_autoware_v2x/install/setup.bash
+V2X_PATH=${AUTOWARE_CARLA_ROOT}/external/zenoh_autoware_v2x/
 
 # Log folder
 LOG_PATH=autoware_log/`date '+%Y-%m-%d_%H:%M:%S'`/
@@ -27,5 +26,6 @@ parallel --verbose --lb ::: \
     "${AUTOWARE_CARLA_ROOT}/external/zenoh-plugin-ros2dds/target/release/zenoh-bridge-ros2dds \
             -n /${VEHICLE_NAME} -d ${ROS_DOMAIN_ID} -c ${ZENOH_BRIDGE_ROS2DDS_CONFIG} -e tcp/${ZENOH_CARLA_IP_PORT} -e tcp/${ZENOH_FMS_IP_PORT} \
             2>&1 | tee ${LOG_PATH}/zenoh_bridge_ros2dds.log" \
-    "sleep 5 && ros2 run v2x_light v2x_light -- -v ${VEHICLE_NAME} --map-info external/zenoh_autoware_v2x/map_info.json \
+    "sleep 5 && uv run --project ${V2X_PATH} ${V2X_PATH}/v2x_light/main.py \
+            -v ${VEHICLE_NAME} --map-info ${V2X_PATH}/map_info.json \
             2>&1 | tee ${LOG_PATH}/v2x_light.log"

--- a/script/bridge_rmw_zenoh/run-bridge-two-vehicles-v2x-with-rmw_zenoh.sh
+++ b/script/bridge_rmw_zenoh/run-bridge-two-vehicles-v2x-with-rmw_zenoh.sh
@@ -15,15 +15,15 @@ parallel --verbose --lb ::: \
                 --zenoh-config ${RMW_ZENOH_CARLA_BRIDGE_CONFIG} \
                 --carla-address ${CARLA_SIMULATOR_IP} --slowdown 2 2>&1 \
                 | tee ${LOG_PATH}/bridge.log" \
-        "uv run --project ${PYTHON_AGENT_PATH} python3 ${PYTHON_AGENT_PATH}/main.py \
+        "uv run --project ${PYTHON_AGENT_PATH} ${PYTHON_AGENT_PATH}/main.py \
                 --host ${CARLA_SIMULATOR_IP} --rolename 'v1' \
                 --position 87.687683,145.671295,0.300000,0.000000,90.000053,0.000000 \
                 2>&1 | tee ${LOG_PATH}/vehicle1.log" \
-        "sleep 1 && uv run --project ${PYTHON_AGENT_PATH} python3 ${PYTHON_AGENT_PATH}/main.py \
+        "sleep 1 && uv run --project ${PYTHON_AGENT_PATH} ${PYTHON_AGENT_PATH}/main.py \
                 --host ${CARLA_SIMULATOR_IP} --rolename 'v2' \
                 --position 92.109985,227.220001,0.300000,0.000000,-90.000298,0.000000 \
                 2>&1 | tee ${LOG_PATH}/vehicle2.log" \
-        "sleep 5 && uv run --project ${V2X_PATH} python3 ${V2X_PATH}/traffic_manager/main.py \
+        "sleep 5 && uv run --project ${V2X_PATH} ${V2X_PATH}/traffic_manager/main.py \
                 2>&1 | tee ${LOG_PATH}/v2x.log" \
-        "sleep 5 && uv run --project ${V2X_PATH} python3 ${V2X_PATH}/intersection_manager/main.py \
+        "sleep 5 && uv run --project ${V2X_PATH} ${V2X_PATH}/intersection_manager/main.py \
                 2>&1 | tee ${LOG_PATH}/v2x.log"

--- a/script/bridge_rmw_zenoh/run-bridge-two-vehicles-with-rmw-zenoh.sh
+++ b/script/bridge_rmw_zenoh/run-bridge-two-vehicles-with-rmw-zenoh.sh
@@ -14,11 +14,11 @@ parallel --verbose --lb ::: \
                 --zenoh-config ${RMW_ZENOH_CARLA_BRIDGE_CONFIG} \
                 --carla-address ${CARLA_SIMULATOR_IP} --slowdown 2 2>&1 \
                 | tee ${LOG_PATH}/bridge.log" \
-        "uv run --project ${PYTHON_AGENT_PATH} python3 ${PYTHON_AGENT_PATH}/main.py \
+        "uv run --project ${PYTHON_AGENT_PATH} ${PYTHON_AGENT_PATH}/main.py \
                 --host ${CARLA_SIMULATOR_IP} --rolename 'v1' \
                 --position 87.687683,145.671295,0.300000,0.000000,90.000053,0.000000 \
                 2>&1 | tee ${LOG_PATH}/vehicle1.log" \
-        "sleep 1 && uv run --project ${PYTHON_AGENT_PATH} python3 ${PYTHON_AGENT_PATH}/main.py \
+        "sleep 1 && uv run --project ${PYTHON_AGENT_PATH} ${PYTHON_AGENT_PATH}/main.py \
                 --host ${CARLA_SIMULATOR_IP} --rolename 'v2' \
                 --position 92.109985,227.220001,0.300000,0.000000,-90.000298,0.000000 \
                 2>&1 | tee ${LOG_PATH}/vehicle2.log"

--- a/script/bridge_rmw_zenoh/run-bridge-v2x-with-rmw_zenoh.sh
+++ b/script/bridge_rmw_zenoh/run-bridge-v2x-with-rmw_zenoh.sh
@@ -15,11 +15,11 @@ parallel --verbose --lb ::: \
                 --zenoh-config ${RMW_ZENOH_CARLA_BRIDGE_CONFIG} \
                 --carla-address ${CARLA_SIMULATOR_IP} 2>&1 \
                 | tee ${LOG_PATH}/bridge.log" \
-        "uv run --project ${PYTHON_AGENT_PATH} python3 ${PYTHON_AGENT_PATH}/main.py \
+        "uv run --project ${PYTHON_AGENT_PATH} ${PYTHON_AGENT_PATH}/main.py \
                 --host ${CARLA_SIMULATOR_IP} --rolename ${VEHICLE_NAME} \
                 --position 87.687683,20.787275,0.300000,0.000000,90.000053,0.000000 \
                 2>&1 | tee ${LOG_PATH}/vehicle.log" \
-        "sleep 5 && uv run --project ${V2X_PATH} python3 ${V2X_PATH}/traffic_manager/main.py \
+        "sleep 5 && uv run --project ${V2X_PATH} ${V2X_PATH}/traffic_manager/main.py \
                 2>&1 | tee ${LOG_PATH}/v2x.log" \
-        "sleep 5 && uv run --project ${V2X_PATH} python3 ${V2X_PATH}/intersection_manager/main.py \
+        "sleep 5 && uv run --project ${V2X_PATH} ${V2X_PATH}/intersection_manager/main.py \
                 2>&1 | tee ${LOG_PATH}/v2x.log"

--- a/script/bridge_rmw_zenoh/run-bridge-with-rmw_zenoh.sh
+++ b/script/bridge_rmw_zenoh/run-bridge-with-rmw_zenoh.sh
@@ -14,6 +14,6 @@ parallel --verbose --lb ::: \
                 --zenoh-config ${RMW_ZENOH_CARLA_BRIDGE_CONFIG} \
                 --carla-address ${CARLA_SIMULATOR_IP} 2>&1 \
                 | tee ${LOG_PATH}/bridge.log" \
-        "uv run --project ${PYTHON_AGENT_PATH} python3 ${PYTHON_AGENT_PATH}/main.py \
+        "uv run --project ${PYTHON_AGENT_PATH} ${PYTHON_AGENT_PATH}/main.py \
                 --host ${CARLA_SIMULATOR_IP} --rolename ${VEHICLE_NAME} \
                 2>&1 | tee ${LOG_PATH}/vehicle.log"

--- a/script/bridge_ros2dds/run-bridge-two-vehicles-v2x.sh
+++ b/script/bridge_ros2dds/run-bridge-two-vehicles-v2x.sh
@@ -15,13 +15,13 @@ parallel --verbose --lb ::: \
                 --zenoh-config ${ZENOH_CARLA_BRIDGE_CONFIG} \
                 --carla-address ${CARLA_SIMULATOR_IP} 2>&1 \
                 | tee ${LOG_PATH}/bridge.log" \
-        "uv run --project ${PYTHON_AGENT_PATH} python3 ${PYTHON_AGENT_PATH}/main.py \
+        "uv run --project ${PYTHON_AGENT_PATH} ${PYTHON_AGENT_PATH}/main.py \
                 --host ${CARLA_SIMULATOR_IP} --rolename 'v1' \
                 --position 87.687683,145.671295,0.300000,0.000000,90.000053,0.000000 \
                 2>&1 | tee ${LOG_PATH}/vehicle1.log" \
-        "sleep 1 && uv run --project ${PYTHON_AGENT_PATH} python3 ${PYTHON_AGENT_PATH}/main.py \
+        "sleep 1 && uv run --project ${PYTHON_AGENT_PATH} ${PYTHON_AGENT_PATH}/main.py \
                 --host ${CARLA_SIMULATOR_IP} --rolename 'v2' \
                 --position 92.109985,227.220001,0.300000,0.000000,-90.000298,0.000000 \
                 2>&1 | tee ${LOG_PATH}/vehicle2.log" \
-        "sleep 5 && uv run --project ${V2X_PATH} python3 ${V2X_PATH}/traffic_manager/main.py" \
-        "sleep 5 && uv run --project ${V2X_PATH} python3 ${V2X_PATH}/intersection_manager/main.py"
+        "sleep 5 && uv run --project ${V2X_PATH} ${V2X_PATH}/traffic_manager/main.py" \
+        "sleep 5 && uv run --project ${V2X_PATH} ${V2X_PATH}/intersection_manager/main.py"

--- a/script/bridge_ros2dds/run-bridge-two-vehicles.sh
+++ b/script/bridge_ros2dds/run-bridge-two-vehicles.sh
@@ -14,11 +14,11 @@ parallel --verbose --lb ::: \
                 --zenoh-config ${ZENOH_CARLA_BRIDGE_CONFIG} \
                 --carla-address ${CARLA_SIMULATOR_IP} --slowdown 2 2>&1 \
                 | tee ${LOG_PATH}/bridge.log" \
-        "uv run --project ${PYTHON_AGENT_PATH} python3 ${PYTHON_AGENT_PATH}/main.py \
+        "uv run --project ${PYTHON_AGENT_PATH} ${PYTHON_AGENT_PATH}/main.py \
                 --host ${CARLA_SIMULATOR_IP} --rolename 'v1' \
                 --position 87.687683,145.671295,0.300000,0.000000,90.000053,0.000000 \
                 2>&1 | tee ${LOG_PATH}/vehicle1.log" \
-        "sleep 1 && uv run --project ${PYTHON_AGENT_PATH} python3 ${PYTHON_AGENT_PATH}/main.py \
+        "sleep 1 && uv run --project ${PYTHON_AGENT_PATH} ${PYTHON_AGENT_PATH}/main.py \
                 --host ${CARLA_SIMULATOR_IP} --rolename 'v2' \
                 --position 92.109985,227.220001,0.300000,0.000000,-90.000298,0.000000 \
                 2>&1 | tee ${LOG_PATH}/vehicle2.log"

--- a/script/bridge_ros2dds/run-bridge-v2x.sh
+++ b/script/bridge_ros2dds/run-bridge-v2x.sh
@@ -15,11 +15,11 @@ parallel --verbose --lb ::: \
                 --zenoh-config ${ZENOH_CARLA_BRIDGE_CONFIG} \
                 --carla-address ${CARLA_SIMULATOR_IP} 2>&1 \
                 | tee ${LOG_PATH}/bridge.log" \
-        "uv run --project ${PYTHON_AGENT_PATH} python3 ${PYTHON_AGENT_PATH}/main.py \
+        "uv run --project ${PYTHON_AGENT_PATH} ${PYTHON_AGENT_PATH}/main.py \
                 --host ${CARLA_SIMULATOR_IP} --rolename ${VEHICLE_NAME} \
                 --position 87.687683,20.787275,0.300000,0.000000,90.000053,0.000000 \
                 2>&1 | tee ${LOG_PATH}/vehicle.log" \
-        "sleep 5 && uv run --project ${V2X_PATH} python3 ${V2X_PATH}/traffic_manager/main.py \
+        "sleep 5 && uv run --project ${V2X_PATH} ${V2X_PATH}/traffic_manager/main.py \
                 2>&1 | tee ${LOG_PATH}/v2x.log" \
-        "sleep 5 && uv run --project ${V2X_PATH} python3 ${V2X_PATH}/intersection_manager/main.py \
+        "sleep 5 && uv run --project ${V2X_PATH} ${V2X_PATH}/intersection_manager/main.py \
                 2>&1 | tee ${LOG_PATH}/v2x.log"

--- a/script/bridge_ros2dds/run-bridge.sh
+++ b/script/bridge_ros2dds/run-bridge.sh
@@ -14,6 +14,6 @@ parallel --verbose --lb ::: \
                 --zenoh-config ${ZENOH_CARLA_BRIDGE_CONFIG} \
                 --carla-address ${CARLA_SIMULATOR_IP} 2>&1 \
                 | tee ${LOG_PATH}/bridge.log" \
-        "uv run --project ${PYTHON_AGENT_PATH} python3 ${PYTHON_AGENT_PATH}/main.py \
+        "uv run --project ${PYTHON_AGENT_PATH} ${PYTHON_AGENT_PATH}/main.py \
                 --host ${CARLA_SIMULATOR_IP} --rolename ${VEHICLE_NAME} \
                 2>&1 | tee ${LOG_PATH}/vehicle.log"


### PR DESCRIPTION
Bump zenoh_autoware_v2x to replace the ROS v2x_light package with a standalone Zenoh Python module, and update the launch side accordingly:

- Launch v2x_light via `uv run main.py` in both run-autoware-v2x.sh and run-autoware-v2x-with-rmw_zenoh.sh, instead of `ros2 run v2x_light`.
- Drop the colcon install overlay sourcing; group rust & uv paths in env.sh and remove uv from the python agent block.
- Allow v2x topics (path_with_lane_id, traffic_signals) through the zenoh-bridge-ros2dds config and the rmw_zenoh V1/V2 router configs.
- Remove the Build step from docs.
- Remove redundant `python3` from `uv run` commands across the scripts